### PR TITLE
Add stats data to top-level apps view

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -28,7 +28,8 @@ const router = new VueRouter({
 new Vue({
   router: router,
   data: {
-    apps: null
+    apps: null,
+    stats: null
   },
   components: {
     IndexPage,
@@ -44,18 +45,31 @@ new Vue({
         success: (apps) => t.apps = apps,
         error: defaultErrorHandler
       })
+    },
+    loadStats: function(){
+      var t = this;
+      $.ajax({
+        url: '/api/stats',
+        dataType: 'json',
+        success: (statistics) => t.stats = statistics,
+        error: defaultErrorHandler
+      })
     }
   },
   created: function(){
     this.loadApps();
+    this.loadStats();
     eventBus.$on('AppAdded', (app) => {
-      this.loadApps()
+      this.loadApps();
+      this.loadStats();
     });
     eventBus.$on('AppUpdated', (app) => {
-      this.loadApps()
+      this.loadApps();
+      this.loadStats();
     });
     eventBus.$on('AppDeleted', (app) => {
-      this.loadApps()
+      this.loadApps();
+      this.loadStats();
     });
   }
 }).$mount('#app')

--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -16,6 +16,8 @@
       </div>
     </h1>
 
+    <h3 class="page-header">Applications</h3>
+
     <div class="row">
       <div class="col-md-12 col-lg-10">
         <!-- <div class="table-responsive"> -->
@@ -68,8 +70,50 @@
     </div>
 
 
-
-
+    <h3 class="page-header">Statistics</h3>
+    <div class="row">
+      <div class="col-md-3 col-lg-3">
+        <div>
+          <table class="table table-striped">
+            <tbody>
+              <tr>
+                <td>
+                  Queue
+                </td>
+                <td v-if="stats">
+                  {{stats.Queue}}
+                </td>
+                <td v-if="!stats">
+                  <div>Loading...</div>
+                </td>                
+              </tr>
+              <tr>
+                <td>
+                  Running
+                </td>
+                <td v-if="stats">
+                  {{stats.Running}}
+                </td>
+                <td v-if="!stats">
+                  <div>Loading...</div>
+                </td>                
+              </tr>
+              <tr>
+                <td>
+                  Complete
+                </td>
+                <td v-if="stats">
+                  {{stats.Complete}}
+                </td>
+                <td v-if="!stats">
+                  <div>Loading...</div>
+                </td>                
+              </tr>                            
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
 
     <fn-app-form></fn-app-form>
   </div>
@@ -82,7 +126,7 @@ import { defaultErrorHandler } from '../lib/helpers';
 import { eventBus } from '../client';
 
 export default {
-  props: ['apps'],
+  props: ['apps','stats'],
   components: {
     FnAppForm
   },

--- a/public/index.html
+++ b/public/index.html
@@ -78,22 +78,16 @@
 
     <div class="container-fluid">
 
-
       <div class="row">
         <div class="col-sm-4 col-md-3 col-lg-2 sidebar">
           <fn-sidebar :apps="apps">
         </div>
         <div class="col-sm-8 col-sm-offset-4 col-md-9 col-md-offset-3 col-lg-10 col-lg-offset-2 main">
           <div>
-
-
-            <router-view :apps="apps"></router-view>
-
+            <router-view :apps="apps" :stats="stats"></router-view>
           </div>
         </div>
       </div>
-
-
 
     </div>
   </div>

--- a/server/controllers/stats.js
+++ b/server/controllers/stats.js
@@ -1,0 +1,13 @@
+var express = require('express');
+var router = express.Router();
+var helpers = require('../helpers/app-helpers.js');
+
+router.get('/', function(req, res) {
+  successcb = function(data){
+    res.json(data);
+  }
+
+  helpers.getApiEndpoint(req, "/stats", {}, successcb, helpers.standardErrorcb(res))
+});
+
+module.exports = router;

--- a/server/router.js
+++ b/server/router.js
@@ -4,5 +4,6 @@ var router = express.Router();
 router.use('/api/apps', require('./controllers/apps.js'))
 router.use('/api/apps', require('./controllers/routes.js'))
 router.use('/api/info', require('./controllers/info.js'))
+router.use('/api/stats', require('./controllers/stats.js'))
 
 module.exports = router;


### PR DESCRIPTION
First set of changes to add statistics to the functions UI.
The only change is to the top-level "apps" view.
Beneath the existing table of apps, there is a new table entitled "statistics",
which lists the three values returned by the /stats API call: queue, running and completed.
![untitled](https://user-images.githubusercontent.com/6053562/29424384-69903d8a-8377-11e7-8146-c01edb5c7801.png)
