### PR TITLE
Break out legend into a separate HTML element and adjust chart widths

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -34,7 +34,7 @@ const backgroundColors = ['rgba(255, 99, 132, 0.2)', 'rgba(54, 162, 235, 0.2)', 
                           'rgba(75, 192, 192, 0.2)', 'rgba(153, 102, 255, 0.2)', 'rgba(255, 159, 64, 0.2)' ];
 const borderColors = ['rgba(255,99,132,1)', 'rgba(54, 162, 235, 1)', 'rgba(255, 206, 86, 1)', 
                       'rgba(75, 192, 192, 1)', 'rgba(153, 102, 255, 1)', 'rgba(255, 159, 64, 1)'];
-export const lineWidthInPixels = 2;
+export const lineWidthInPixels = 1;
 export const pointRadiusInPixels = 0.5;
 var backgroundColorMap = {}
 var borderColorMap = {}

--- a/client/components/CompletedGraph.vue
+++ b/client/components/CompletedGraph.vue
@@ -3,15 +3,14 @@
     :chart-data="datacollection"
     :options="{
       responsive: true, 
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
       title: {
         display: false,
         text: 'Completed'
       },
       legend: {
-        display: true,
-        position: 'left'
-      },  
+        display: false,
+      },
       animation: {
         duration:0 // turn off annoying bouncing animation
       },
@@ -34,7 +33,7 @@
  import { eventBus } from '../client';
  import { getBackgroundColorFor, getBorderColorFor, lineWidthInPixels, pointRadiusInPixels} from '../client'; 
  import { truncate} from '../pages/utilities.js'; 
- 
+
   export default {
     components: {
       LineChart,
@@ -49,7 +48,7 @@
       }
     },
     mounted () {
-      //this.updateChart()
+      //this.updateChart();
     },
     methods: {
       updateChart () {
@@ -59,8 +58,9 @@
           this.datacollection["datasets"]=[];
           for (var thisPath in this.stats.FunctionStatsMap){
             var dataSetForPath = {
-              label: truncate(thisPath,15) + ": "+ this.stats.FunctionStatsMap[thisPath].Complete,
-              backgroundColor: getBackgroundColorFor(thisPath),
+              label: thisPath + ": "+ this.stats.FunctionStatsMap[thisPath].Complete,
+              fill: false, // Only use fill if chart is stacked
+              backgroundColor: 'white', // needed if fill is false to set fill color in legend
               borderColor: getBorderColorFor(thisPath),
               borderWidth: lineWidthInPixels,
               radius:pointRadiusInPixels,
@@ -69,6 +69,26 @@
             this.datacollection["datasets"].push(dataSetForPath);
              
           }
+          var legs = document.getElementById("completedGraphLegend");
+        
+          // legend  
+          var text = [];
+          text.push('<ul class=\'' + 'chartLegend\'>');
+          var chartDataDatasets = this.datacollection["datasets"];
+          var chartDataDatasetsLength = chartDataDatasets.length;
+		  for (var i = 0; i < chartDataDatasets.length; i++) {
+			text.push('<li><span class=\'chartLabelEmblem\' style=\'' +
+			  'background-color:' + chartDataDatasets[i].backgroundColor + '; ' +
+		      'border-color:' + chartDataDatasets[i].borderColor + ';' +
+			  '\'></span>');
+			if (chartDataDatasets[i].label) {
+			  text.push('<span class=\'chartLabelText\'>'+chartDataDatasets[i].label+'</span>');
+			}
+			text.push('</li>');
+		  }
+		  text.push('</ul>');
+          legs.innerHTML  = text.join(''); 
+          // end of legend   
         }
       }
     },
@@ -83,4 +103,26 @@
 </script>
 
 <style>
+.chartLegend{
+}
+.chartLabelEmblem {
+  float:left;
+  width:40px;
+  height:14px;
+  line-height:20px;
+  margin-top:3px;
+  margin-left:10px;
+  margin-right:6px;
+  border:1px solid;
+  font-size:8px;
+}
+.chartLabelText {
+  font-size:14px;
+}
+
+ul.chartLegend{
+  margin-right:10px;
+  list-style-type: none;
+  padding-left:0px;
+}
 </style>

--- a/client/components/FailedGraph.vue
+++ b/client/components/FailedGraph.vue
@@ -3,15 +3,14 @@
     :chart-data="datacollection"
     :options="{
       responsive: true, 
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
       title: {
         display: false,
         text: 'Failed'
       },
       legend: {
-        display: true,
-        position: 'left'
-      },  
+        display: false,
+      },
       animation: {
         duration:0 // turn off annoying bouncing animation
       },
@@ -34,7 +33,7 @@
  import { eventBus } from '../client';
  import { getBackgroundColorFor, getBorderColorFor, lineWidthInPixels, pointRadiusInPixels} from '../client'; 
  import { truncate} from '../pages/utilities.js'; 
- 
+
   export default {
     components: {
       LineChart,
@@ -49,7 +48,7 @@
       }
     },
     mounted () {
-      //this.updateChart()
+      //this.updateChart();
     },
     methods: {
       updateChart () {
@@ -59,8 +58,9 @@
           this.datacollection["datasets"]=[];
           for (var thisPath in this.stats.FunctionStatsMap){
             var dataSetForPath = {
-              label: truncate(thisPath,15) + ": "+ this.stats.FunctionStatsMap[thisPath].Failed,
-              backgroundColor: getBackgroundColorFor(thisPath),
+              label: thisPath + ": "+ this.stats.FunctionStatsMap[thisPath].Failed,
+              fill: false, // Only use fill if chart is stacked
+              backgroundColor: 'white', // needed if fill is false to set fill color in legend
               borderColor: getBorderColorFor(thisPath),
               borderWidth: lineWidthInPixels,
               radius:pointRadiusInPixels,
@@ -69,6 +69,26 @@
             this.datacollection["datasets"].push(dataSetForPath);
              
           }
+          var legs = document.getElementById("failedGraphLegend");
+        
+          // legend  
+          var text = [];
+          text.push('<ul class=\'' + 'chartLegend\'>');
+          var chartDataDatasets = this.datacollection["datasets"];
+          var chartDataDatasetsLength = chartDataDatasets.length;
+		  for (var i = 0; i < chartDataDatasets.length; i++) {
+			text.push('<li><span class=\'chartLabelEmblem\' style=\'' +
+			  'background-color:' + chartDataDatasets[i].backgroundColor + '; ' +
+		      'border-color:' + chartDataDatasets[i].borderColor + ';' +
+			  '\'></span>');
+			if (chartDataDatasets[i].label) {
+			  text.push('<span class=\'chartLabelText\'>'+chartDataDatasets[i].label+'</span>');
+			}
+			text.push('</li>');
+		  }
+		  text.push('</ul>');
+          legs.innerHTML  = text.join(''); 
+          // end of legend   
         }
       }
     },
@@ -83,4 +103,26 @@
 </script>
 
 <style>
+.chartLegend{
+}
+.chartLabelEmblem {
+  float:left;
+  width:40px;
+  height:14px;
+  line-height:20px;
+  margin-top:3px;
+  margin-left:10px;
+  margin-right:6px;
+  border:1px solid;
+  font-size:8px;
+}
+.chartLabelText {
+  font-size:14px;
+}
+
+ul.chartLegend{
+  margin-right:10px;
+  list-style-type: none;
+  padding-left:0px;
+}
 </style>

--- a/client/components/QueuedGraph.vue
+++ b/client/components/QueuedGraph.vue
@@ -3,23 +3,22 @@
     :chart-data="datacollection"
     :options="{
       responsive: true, 
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
       title: {
         display: false,
         text: 'Queued'
       },
       legend: {
-        display: true,
-        position: 'left'
-      },  
+        display: false,
+      },
       animation: {
         duration:0 // turn off annoying bouncing animation
       },
       scales: {
         yAxes: [{
-          stacked: false,  // QueuedGraph is not stacked
+          stacked: false, // QueuedGraph is not stacked
           ticks: {
-            suggestedMax: 10                
+            suggestedMax: 10
           }
         }]
       }     
@@ -34,7 +33,7 @@
  import { eventBus } from '../client';
  import { getBackgroundColorFor, getBorderColorFor, lineWidthInPixels, pointRadiusInPixels} from '../client'; 
  import { truncate} from '../pages/utilities.js'; 
- 
+
   export default {
     components: {
       LineChart,
@@ -49,7 +48,7 @@
       }
     },
     mounted () {
-      //this.updateChart()
+      //this.updateChart();
     },
     methods: {
       updateChart () {
@@ -59,7 +58,7 @@
           this.datacollection["datasets"]=[];
           for (var thisPath in this.stats.FunctionStatsMap){
             var dataSetForPath = {
-              label: truncate(thisPath,15) + ": "+ this.stats.FunctionStatsMap[thisPath].Queue,
+              label: thisPath + ": "+ this.stats.FunctionStatsMap[thisPath].Queue,
               fill: false, // Only use fill if chart is stacked
               backgroundColor: 'white', // needed if fill is false to set fill color in legend
               borderColor: getBorderColorFor(thisPath),
@@ -70,6 +69,26 @@
             this.datacollection["datasets"].push(dataSetForPath);
              
           }
+          var legs = document.getElementById("queuedGraphLegend");
+        
+          // legend  
+          var text = [];
+          text.push('<ul class=\'' + 'chartLegend\'>');
+          var chartDataDatasets = this.datacollection["datasets"];
+          var chartDataDatasetsLength = chartDataDatasets.length;
+		  for (var i = 0; i < chartDataDatasets.length; i++) {
+			text.push('<li><span class=\'chartLabelEmblem\' style=\'' +
+			  'background-color:' + chartDataDatasets[i].backgroundColor + '; ' +
+		      'border-color:' + chartDataDatasets[i].borderColor + ';' +
+			  '\'></span>');
+			if (chartDataDatasets[i].label) {
+			  text.push('<span class=\'chartLabelText\'>'+chartDataDatasets[i].label+'</span>');
+			}
+			text.push('</li>');
+		  }
+		  text.push('</ul>');
+          legs.innerHTML  = text.join(''); 
+          // end of legend   
         }
       }
     },
@@ -84,4 +103,27 @@
 </script>
 
 <style>
+.chartLegend{
+  float:left;
+}
+.chartLabelEmblem {
+  float:left;
+  width:40px;
+  height:14px;
+  line-height:20px;
+  margin-top:3px;
+  margin-left:10px;
+  margin-right:6px;
+  border:1px solid;
+  font-size:8px;
+}
+.chartLabelText {
+  font-size:14px;
+}
+
+ul.chartLegend{
+  margin-right:10px;
+  list-style-type: none;
+  padding-left:0px;
+}
 </style>

--- a/client/components/RunningGraph.vue
+++ b/client/components/RunningGraph.vue
@@ -3,15 +3,14 @@
     :chart-data="datacollection"
     :options="{
       responsive: true, 
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
       title: {
         display: false,
         text: 'Running'
       },
       legend: {
-        display: true,
-        position: 'left'
-      },  
+        display: false,
+      },
       animation: {
         duration:0 // turn off annoying bouncing animation
       },
@@ -34,7 +33,7 @@
  import { eventBus } from '../client';
  import { getBackgroundColorFor, getBorderColorFor, lineWidthInPixels, pointRadiusInPixels} from '../client'; 
  import { truncate} from '../pages/utilities.js'; 
-  
+
   export default {
     components: {
       LineChart,
@@ -49,7 +48,7 @@
       }
     },
     mounted () {
-      //this.updateChart()
+      //this.updateChart();
     },
     methods: {
       updateChart () {
@@ -59,7 +58,7 @@
           this.datacollection["datasets"]=[];
           for (var thisPath in this.stats.FunctionStatsMap){
             var dataSetForPath = {
-              label: truncate(thisPath,15) + ": "+ this.stats.FunctionStatsMap[thisPath].Running,
+              label: thisPath + ": "+ this.stats.FunctionStatsMap[thisPath].Running,
               fill: false, // Only use fill if chart is stacked
               backgroundColor: 'white', // needed if fill is false to set fill color in legend
               borderColor: getBorderColorFor(thisPath),
@@ -70,6 +69,26 @@
             this.datacollection["datasets"].push(dataSetForPath);
              
           }
+          var legs = document.getElementById("runningGraphLegend");
+        
+          // legend  
+          var text = [];
+          text.push('<ul class=\'' + 'chartLegend\'>');
+          var chartDataDatasets = this.datacollection["datasets"];
+          var chartDataDatasetsLength = chartDataDatasets.length;
+		  for (var i = 0; i < chartDataDatasets.length; i++) {
+			text.push('<li><span class=\'chartLabelEmblem\' style=\'' +
+			  'background-color:' + chartDataDatasets[i].backgroundColor + '; ' +
+		      'border-color:' + chartDataDatasets[i].borderColor + ';' +
+			  '\'></span>');
+			if (chartDataDatasets[i].label) {
+			  text.push('<span class=\'chartLabelText\'>'+chartDataDatasets[i].label+'</span>');
+			}
+			text.push('</li>');
+		  }
+		  text.push('</ul>');
+          legs.innerHTML  = text.join(''); 
+          // end of legend   
         }
       }
     },
@@ -84,4 +103,26 @@
 </script>
 
 <style>
+.chartLegend{
+}
+.chartLabelEmblem {
+  float:left;
+  width:40px;
+  height:14px;
+  line-height:20px;
+  margin-top:3px;
+  margin-left:10px;
+  margin-right:6px;
+  border:1px solid;
+  font-size:8px;
+}
+.chartLabelText {
+  font-size:14px;
+}
+
+ul.chartLegend{
+  margin-right:10px;
+  list-style-type: none;
+  padding-left:0px;
+}
 </style>

--- a/client/components/StatsChart.vue
+++ b/client/components/StatsChart.vue
@@ -1,29 +1,33 @@
 <template >
   <div class="row">
-    <div class="col-lg-6 col-md-12 col-sm-12">
+    <div class="singleChart">
       <h4 class="chart-title">Queued: {{this.stats.Queue}}</h4>
+      <div id="queuedGraphLegend"></div>
       <queued-graph :stats="stats" :statshistory="statshistory"></queued-graph>
     </div>
-    <div class="col-lg-6 col-md-12 col-sm-12">
+    <div class="singleChart">
       <h4 class="chart-title">Running: {{this.stats.Running}}</h4>
+      <div id="runningGraphLegend"></div>
       <running-graph :stats="stats" :statshistory="statshistory"></running-graph>
-    </div>
-    <div class="col-lg-6 col-md-12 col-sm-12">
+    </div>       
+    <div class="singleChart">
       <h4 class="chart-title">Completed: {{this.stats.Complete}}</h4>
+      <div id="completedGraphLegend"></div>
       <completed-graph :stats="stats" :statshistory="statshistory"></completed-graph>
     </div>
-    <div class="col-lg-6 col-md-12 col-sm-12">
+    <div class="singleChart">
       <h4 class="chart-title">Failed: {{this.stats.Failed}}</h4>
+      <div id="failedGraphLegend"></div>
       <failed-graph :stats="stats" :statshistory="statshistory"></failed-graph>
-    </div>
-  </div>    
+    </div> 
+  </div>
 </template>
 
 <script>
   import { eventBus } from '../client';
+  import RunningGraph from '../components/RunningGraph';
   import QueuedGraph from '../components/QueuedGraph';
   import CompletedGraph from '../components/CompletedGraph';
-  import RunningGraph from '../components/RunningGraph';
   import FailedGraph from '../components/FailedGraph';
  
   export default {
@@ -42,6 +46,33 @@
 </script>
 
 <style>
+
+@media only screen and (min-width: 1500px) {
+  .singleChart {
+    width:25%;
+    float:left;
+  }
+}
+@media only screen and (min-width: 1160px) and (max-width: 1499px) {
+  .singleChart {
+    width:33%;
+    float:left;
+  }
+}
+@media only screen and (min-width: 450px) and (max-width: 1159px) {
+  .singleChart {
+    width:50%;
+    float:left;
+  }
+}
+@media only screen and (max-width: 449) {
+  .singleChart {
+    width:100%;
+    float:left;
+  }  
+}
+
+
 .chart-title{
   text-align:center;
   padding-bottom:10px;

--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -87,7 +87,6 @@
 
 <script>
 import FnAppForm from '../components/FnAppForm';
-import LineExample from '../components/LineChart.js'
 import StatsChart from '../components/StatsChart'
 
 import { defaultErrorHandler } from '../lib/helpers';
@@ -102,7 +101,6 @@ export default {
   },
   components: {
     FnAppForm,
-    LineExample,
     StatsChart
   },
   methods: {


### PR DESCRIPTION
In this change I have rewritten the legend code so that the legend is a separate div which we can style directly. Previously the legend was part of the chart canvas so we could to control it directly. The legend is now floated on top of the chart, with each legend entry in a neat vertical list.

I have also changed the responsive styles used to determine how many charts are displayed in a row. This is very easy to change, but currently I have it so that
  Displays wider than 1500px: 4 charts/row
  Displays wider than 1160px up to 1499: 3 charts/row
  Displays wider than 450px up to 1159: 2 charts/row
  Displays narrower than 449px: 1 chart/row
The transitions are defined at the bottom of `StatsChart.vue`. Inevitably close to the transition points the chart may be wider or narrower than is ideal: this is a matter of judgement.

Screenshots: 
**1500px browser width**
![functions ui - mozilla firefox 26092017 171022](https://user-images.githubusercontent.com/6053562/30871535-1fc00f14-a2df-11e7-92cd-8d443cf24608.jpg)
**1160px browser width**
![functions ui - mozilla firefox 26092017 171043](https://user-images.githubusercontent.com/6053562/30871563-2f8a7b46-a2df-11e7-9da2-8d3bf98df8c9.jpg)
**450px browser width**
![functions ui - mozilla firefox 26092017 171103](https://user-images.githubusercontent.com/6053562/30871593-48c93c1e-a2df-11e7-9c99-89ca69c8d274.jpg)
**400px browser width**
![functions ui - mozilla firefox 26092017 171114](https://user-images.githubusercontent.com/6053562/30871617-5f183574-a2df-11e7-9352-44713463b157.jpg)

px browser**

