### PR TITLE
Corrections to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,20 @@ All functions in an app:
 ### 1) Install dependencies
 
 ```sh
-npm install && npm install -g webpack
+npm install
+sudo npm install -g webpack
 ```
 
 ### 2) Start Functions API (see [Fn on Github](http://github.com/fnproject/fn))
 
 ```sh
 fn start
+```
+
+### 4) Compile assets
+
+```sh
+webpack
 ```
 
 ### 3) Start web server
@@ -46,12 +53,6 @@ PORT=4000 API_URL=http://localhost:8080 npm start
 
 * `PORT` - port to run UI on. Optional, 4000 by default
 * `API_URL` - Functions API URL. Required
-
-### 4) Launch automatic asset recompilation
-
-```sh
-webpack --watch
-```
 
 ### 5) View in browser
 


### PR DESCRIPTION
I've made a few changes to the build instructions:
* I've found you need to run `npm install -g webpack` as root (probably since this installs it globally)
* The instructions suggest running `webpack --watch` and then immediately starting the browser. This means the user is likely to get a broken page since the asset recompilation may not have finished (it takes 20-30 seconds).  I've therefore moved the call to `webpack` to be before the server is started (and before the browser is started). I've also removed `--watch` since this makes it clearer to the user when the compilation has finished and it's OK to proceed with the next step.