### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 sudo npm install -g webpack
 ```
 
-### 2) Start Functions API (see [Fn on Github](http://github.com/fnproject/fn))
+### 2) Start Functions API (see [Fn on GitHub](http://github.com/fnproject/fn))
 
 ```sh
 fn start

--- a/client/components/FnWelcomeSection.vue
+++ b/client/components/FnWelcomeSection.vue
@@ -20,12 +20,12 @@
       </li>
       <li>
         <a href="https://github.com/fnproject/fn" target="_blank">
-          <i class="fa fa-github"></i> Fn Github
+          <i class="fa fa-github"></i> Fn GitHub
         </a>
       </li>
       <li>
         <a href="https://github.com/fnproject/ui" target="_blank">
-        <i class="fa fa-github"></i> Fn UI Github
+        <i class="fa fa-github"></i> Fn UI GitHub
         </a>
       </li>
     </ul>

--- a/public/index.html
+++ b/public/index.html
@@ -64,12 +64,12 @@
             </li>
             <li>
               <a href="https://github.com/fnproject/fn" target="_blank">
-                <i class="fa fa-github"></i> Fn Github
+                <i class="fa fa-github"></i> Fn GitHub
               </a>
             </li>
             <li>
               <a href="https://github.com/fnproject/ui" target="_blank">
-                <i class="fa fa-github"></i> Fn UI Github
+                <i class="fa fa-github"></i> Fn UI GitHub
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Just a minor typo fix `Github` -> `GitHub`