### PR TITLE
Fix per-app stats to handle two apps having routes with the same path…

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -55,17 +55,10 @@ new Vue({
       if (this.statshistory==null){
         this.statshistory = [];
         for (var i = 0; i < numXValues; i++) {
-          this.statshistory.push(
-            {
-              Queue: 0,
-              Running: 0,
-              Complete: 0,
-              FunctionStatsMap: {}
-            }      	  
-          )
+          this.statshistory.push({Apps:{}})
         } 
       }
-    },    
+    },     
     loadStats: function(){
       if (this.autorefresh) {
         $.ajax({
@@ -89,21 +82,6 @@ new Vue({
           this.statshistory.shift();
         }
       }        
-      
-      // do the stats contain a new function?
-      // create an array containing the paths in the penultimate FunctionStatsMap
-      var previousKnownFunctions = Object.keys(this.statshistory[this.statshistory.length-2].FunctionStatsMap);
-      // create an array containing the paths in the last FunctionStatsMap
-      var nowKnownFunctions = Object.keys(this.statshistory[this.statshistory.length-1].FunctionStatsMap);
-      for (var j = 0; j < nowKnownFunctions.length; j++){
-        if (previousKnownFunctions.indexOf(nowKnownFunctions[j])==-1){
-          var newFunction = nowKnownFunctions[j];
-          // we have a new function: backfill all the earlier stats with zero values for this function
-          for (var k = 0; k < this.statshistory.length-1; k++){
-            this.statshistory[k].FunctionStatsMap[newFunction]={Queue:0, Running:0, Complete:0, Failed:0};
-          }
-        }
-      }     
       // we have new stats: notify any graphs to update themselves 
       eventBus.$emit('statsRefreshed');
     }

--- a/client/components/CompletedGraph.vue
+++ b/client/components/CompletedGraph.vue
@@ -45,7 +45,7 @@
       'routes',
       'stats',
       'statshistory',
-      'appname'
+      'appname' // this will be unset if this graph is for all apps
     ],
     data () {
       return {

--- a/client/components/FailedGraph.vue
+++ b/client/components/FailedGraph.vue
@@ -45,7 +45,7 @@
       'routes',
       'stats',
       'statshistory',
-      'appname'
+      'appname' // this will be unset if this graph is for all apps
     ],
     data () {
       return {

--- a/client/components/QueuedGraph.vue
+++ b/client/components/QueuedGraph.vue
@@ -45,7 +45,7 @@
       'routes',
       'stats',
       'statshistory',
-      'appname'
+      'appname' // this will be unset if this graph is for all apps
     ],
     data () {
       return {

--- a/client/components/RunningGraph.vue
+++ b/client/components/RunningGraph.vue
@@ -45,7 +45,7 @@
       'routes',
       'stats',
       'statshistory',
-      'appname'
+      'appname' // this will be unset if this graph is for all apps
     ],
     data () {
       return {

--- a/client/components/graphUtilities.js
+++ b/client/components/graphUtilities.js
@@ -5,51 +5,61 @@ export function updateChart (chart,graphTypeArg,isStacked) {
 
   // work out the name of the div that contains the legend: this must exist in the corresponding *Graph.vue file
   // work out the function to extract the required metric from a stats object from JSON
-  var graphLegendDivName;
-  var dataGetter;
+  var graphLegendDivName
+  var metricGetter;
   switch(graphTypeArg){
     case graphType.QUEUED:
       graphLegendDivName="queuedGraphLegend";
-      dataGetter=aStat => aStat.FunctionStatsMap[thisPath].Queue;
+      metricGetter=aRoute => aRoute.Queue;
       break;
     case graphType.RUNNING:
       graphLegendDivName="runningGraphLegend";
-      dataGetter=aStat => aStat.FunctionStatsMap[thisPath].Running;
+      metricGetter=aRoute => aRoute.Running;
       break;
     case graphType.COMPLETED:
       graphLegendDivName="completedGraphLegend";
-      dataGetter=aStat => aStat.FunctionStatsMap[thisPath].Complete;
+      metricGetter=aRoute => aRoute.Complete;
       break;
     case graphType.FAILED:
       graphLegendDivName="failedGraphLegend";
-      dataGetter=aStat => aStat.FunctionStatsMap[thisPath].Failed;
+      metricGetter=aRoute => aRoute.Failed;
       break;
   }
 
   // update the chart to display data for the routes in "routes", or for all routes if "routes" is not set 
-  var totalCount = 0; 
   if (chart.statshistory && chart.stats){
-      chart.datacollection = {};
-      chart.datacollection["labels"]= chart.statshistory.map(eachStatistic => "" );
-      chart.datacollection["datasets"]=[];
-    for (var thisPath in chart.stats.FunctionStatsMap){
-      if (chart.routes==null || isPathIn(thisPath,chart.routes)){
-        totalCount = totalCount + dataGetter(chart.stats);
-        var dataSetForPath = {
-          label: thisPath + ": "+ dataGetter(chart.stats),
-          fill: isStacked, // Use fill for stacked charts to distingush them from non-stacked charts
-          backgroundColor: isStacked ? getBackgroundColorFor(thisPath) : 'white', // Set fill color for stacked charts
-          borderColor: getBorderColorFor(thisPath),
-          borderWidth: lineWidthInPixels,
-          radius:pointRadiusInPixels,
-          data: chart.statshistory.map(dataGetter) // use the appropriate dataGetter for this particular graph type
-        };
-        chart.datacollection["datasets"].push(dataSetForPath);
+    chart.datacollection = {};
+    chart.datacollection["labels"]= chart.statshistory.map(eachStatistic => "" );
+    chart.datacollection["datasets"]=[];
+
+    // update the graph 
+    // and also calculate and display the total count
+    var totalCount = 0; 
+    if (chart.appname==null){
+      // display all routes for all apps
+      for (var thisAppName in chart.stats.Apps){
+        var thisApp = chart.stats.Apps[thisAppName];
+        for (var thisPath in thisApp.Routes){
+          totalCount += displayRoute(chart,thisAppName,thisPath,metricGetter,isStacked);
+        }
+      }
+    } else {
+      // display routes for a specific app
+      var thisApp = chart.stats.Apps[chart.appname];
+      if (thisApp!=null){
+        for (var thisPath in thisApp.Routes){
+          totalCount += displayRoute(chart,chart.appname,thisPath,metricGetter,isStacked);
+        }      
+      } else {
+        // we're displaying an app, but there's no data about it in the stats returned by Fn server
+        // this means that no route in this app was called since the server was started
+        // since these graphs currently follow the convention that they only display lines for routes that have been actually used,
+        // we display nothing here. https://github.com/fnproject/ui/issues/18  proposes this be changed, but that's a wider issue.
       }
     }
     chart.total = totalCount;
     
-    // legend  
+    // now examine the data that the graph is displaying and use it to construct the legend  
     var legs = document.getElementById(graphLegendDivName);
     var text = [];
     text.push('<ul class=\'' + 'chartLegend\'>');
@@ -69,22 +79,52 @@ export function updateChart (chart,graphTypeArg,isStacked) {
     if (legs!=null){
       legs.innerHTML  = text.join(''); 
     }
-    // end of legend   
   }
-
 }
 
-// return whether any of the specified routes has the specified path
-// thisPath - string
-// routes - an array of route objects
-export function isPathIn(path,routes){
-  var result = false; 
-  for (var k= 0; k < routes.length; k++){
-       if (path==routes[k].path){
-       return true;
-      }
+// for the specified appName and path, display a single line on the specified chart, showing historical values of the metric 
+// in addition, return the current value of the metric 
+function displayRoute(chart,appName,path,metricGetter,isStacked) {
+  var thisApp = chart.stats.Apps[appName];
+  var value = getMetricFor(chart.stats,appName,path,metricGetter)
+  // assemble an array containing historical values of the metric that this graph is displaying
+  var routeHistory = [];  
+  for (var i = 0; i < chart.statshistory.length; i++) {
+    routeHistory.push(getMetricFor(chart.statshistory[i],appName,path,metricGetter));
   }
-};
+  var dataSetForPath = {
+    label: path + ": "+ value,
+    fill: isStacked, // Use fill for stacked charts to distingush them from non-stacked charts
+    backgroundColor: isStacked ? getBackgroundColorFor(path) : 'white', // Use a fill color for stacked charts
+    borderColor: getBorderColorFor(path),
+    borderWidth: lineWidthInPixels,
+    radius:pointRadiusInPixels,
+    data: routeHistory
+  };
+  chart.datacollection["datasets"].push(dataSetForPath);
+  return value;
+}
+
+// return the metric value from the specified stats object for the specified appName and path
+// if either the appName or path are not found then zero is returned
+function getMetricFor(aStats,appName,path,metricGetter){
+  var app = aStats.Apps[appName];
+  if (app==null){
+    // we didn't have any information about this app at the time this historical stat was added
+    // either we have a partially-initialised statshistory or the app has not been created yet
+    return 0;
+  } else {
+    var route = app.Routes[path];
+    if (route==null){
+      // although we had information about this app at the time this historical stat was added
+      // we didn't have any information about the routre
+      // this means the route has not been created yet
+      return 0;
+    } else {
+      return metricGetter(route);
+    }
+  }
+}
 
 export var graphType = {
   QUEUED: 0,


### PR DESCRIPTION
This PR fixes a bug which meant that the UI tool could not distinguish between two routes, in different apps, which had the same path.

The root cause of the bug was that the data returned by the Fn server (`/stats`) was simply a list of route stats, keyed by path. So this would not distinguish between two routes, in different apps, which had the same path. That bug is fixed by PR https://github.com/fnproject/fn/pull/735 , which reorganises the data returned into two levels: app and then path.

This PR makes use of the updated API and now will correctly handle two apps having routes with the same path.

(As an aside, when on the "all apps" chart, the lines are currently labelled only by path. They do not mention the app. Although these will display duplicate paths correctly, a use will have to navigate down to the page for the individual app to be sure which line is the one they want. An obvious change would be to display the app name as well, but I'm concerned that this would make the legend too big. That's probably worth fixing, but I think we can do that as a separate change)