### PR TITLE
Add server-side logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ PORT=4000 FN_API_URL=http://localhost:8080 npm start
 ### 5) View in browser
 
 [http://localhost:4000/](http://localhost:4000/)
+
+### Configuring log levels
+
+UI uses [console-logging](https://www.npmjs.com/package/config-logger) for server-side logging. 
+This supports log levels of `debug`, `verbose`, `info`, `warn` and `error`. By default the log level is `info` (this is configured in `config/default.json`). To set a log level of `debug`, use
+```
+NODE_CONFIG='{"logLevel":"debug"}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
+
+```

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,3 @@
+{
+  "logLevel": "info"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FunctionsUI",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,6 +15,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -2414,11 +2419,30 @@
         "object-visit": "1.0.1"
       }
     },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
+    },
+    "config": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.12.0.tgz",
+      "integrity": "sha1-Aq0dgWyS1tqxxxPXNN1emTlE5Bg="
+    },
+    "config-logger": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/config-logger/-/config-logger-0.0.4.tgz",
+      "integrity": "sha1-oBm3zNm4ma5FLbwFpADHkVBbzuM=",
+      "requires": {
+        "config": "1.12.0",
+        "winston": "0.9.0"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -3860,6 +3884,11 @@
         }
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -4315,6 +4344,11 @@
           }
         }
       }
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "file-loader": {
       "version": "0.8.5",
@@ -5502,6 +5536,11 @@
           }
         }
       }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
       "version": "3.3.1",
@@ -6847,6 +6886,11 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -11784,6 +11828,11 @@
         }
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -16125,6 +16174,20 @@
             "window-size": "0.1.0"
           }
         }
+      }
+    },
+    "winston": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.9.0.tgz",
+      "integrity": "sha1-tXJubEIpHjBeNihs566fO3SlJ6g=",
+      "requires": {
+        "async": "0.9.2",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-runtime": "^6.26.0",
     "body-parser": "^1.15.2",
     "chart.js": "^2.6.0",
+    "config-logger": "0.0.4",
     "exports-loader": "^0.6.3",
     "express": "~4.13.4",
     "file-loader": "^0.8.5",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+var logger = require('config-logger');
+
 var express = require('express');
 var path = require('path');
 var url = require('url');
@@ -10,7 +12,7 @@ var app = express();
 var isProduction = process.env.NODE_ENV === 'production';
 var apiUrl = url.parse(process.env.FN_API_URL);
 if (!apiUrl || !apiUrl.hostname) {
-  console.log("API URL not set. Please specify Functions API URL via environment variable, e.g. FN_API_URL=http://localhost:8080 npm start");
+  logger.error("API URL not set. Please specify Functions API URL via environment variable, e.g. FN_API_URL=http://localhost:8080 npm start");
   process.exit(1);
 }
 
@@ -26,6 +28,6 @@ app.use(require('./server/router.js'));
 app.disable('etag');
 
 app.listen(port, function () {
-  console.log('Using API url: ' + apiUrl.host);
-  console.log('Server running on port ' + port);
+  logger.info('Using API url: ' + apiUrl.host);
+  logger.info('Server running on port ' + port);
 });

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var url = require('url');
 var request = require('request');
+var logger = require('config-logger');
 
 exports.extend = function(target) {
     var sources = [].slice.call(arguments, 1);
@@ -21,7 +22,7 @@ exports.apiFullUrl = function(req, path) {
 exports.getApiEndpoint = function(req, path, params, successcb, errorcb) {
   var url = exports.apiFullUrl(req, path);
 
-  console.log("GET " + url + ", params: ", params);
+  logger.debug("GET " + url + ", params: ", params);
 
   options = {url: url, qs: params}
 
@@ -41,7 +42,7 @@ exports.execApiEndpoint = function(method, req, path, params, postfields, succes
     json: postfields
   };
 
-  console.log(options.method + " " + options.uri + ", params: ", options.body);
+  logger.debug(options.method + " " + options.uri + ", params: ", options.body);
 
   options = exports.addAuth(options, req)
 
@@ -55,7 +56,7 @@ exports.execApiEndpointRaw = function(method, req, path, params, postfields, suc
     json: postfields
   };
 
-  console.log(options.method + " " + options.uri + ", params: ", options.body);
+  logger.debug(options.method + " " + options.uri + ", params: ", options.body);
 
   options = exports.addAuth(options, req)
 
@@ -122,7 +123,7 @@ exports.requestCBRaw = function (successcb, errorcb, error, response, body) {
 
 exports.standardErrorcb = function(res){
   return function(status, err){
-    console.log("Error. Api responded with ", status, err);
+    logger.error("Error. Api responded with ", status, err);
     var text = "Something went terribly wrong (Status Code: " + status + ") ";
     if (err){
       text = "Error: " + err;


### PR DESCRIPTION
This PR uses [config-logger](https://www.npmjs.com/package/config-logger) to adds support  for different log levels in the server.

Messages that were previously written directly to `console.log` are now either `debug`, `error` or `info` logging. The default log level is `info`. The log level can be configured at startup, and the `README` has been updated with instructions on how to configure it. 

This fixes issue https://github.com/fnproject/ui/issues/34.

There is no change to client-side logging (currently this isn't used much).