### PR TITLE
Configure request options

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,20 @@
+# Configuration options
+
+Configuration options are set in `config/default.json`. 
+
+```
+{
+  "fnApiOptions": {
+    "pool": {
+      "maxSockets": "Infinity"
+    }
+  }
+}
+```
+
+`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when pooling the Fn server for statistics.
+
+These can be configured by changing `config/default.json` or setting `NODE_CONFIG`. For example, to set `maxSockets` to `1`:
+```
+NODE_CONFIG='{"fnApiOptions": {"pool": {"maxSockets": 1}}}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
+```

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,7 +1,19 @@
 # Configuration options
 
-Configuration options are set in `config/default.json`. 
+## Configuration using environment variables
 
+* `PORT` - port to run UI on. Optional, 4000 by default
+* `FN_API_URL` - Functions API URL. Required
+* `NODE_CONFIG` - node-config configuration options
+
+## Configuration using node-config
+
+Some configuration options are specified using [node-config](https://www.npmjs.com/package/config). 
+These are read from a configuration file  `config/default.json` and may be configured by changing that file.
+specifying a different configuraiton file (see the [node-config](https://www.npmjs.com/package/config) documentation for details)
+or by using the `NODE_CONFIG` environment variable.
+
+Here is `config/default.json`:
 ```
 {
   "fnApiOptions": {
@@ -12,9 +24,11 @@ Configuration options are set in `config/default.json`.
 }
 ```
 
-`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option. [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
+The following configuration option may be specified this way:
 
-To specify an option, either modify `config/default.json` or set `NODE_CONFIG`. For example, to set the `pool` option's `maxSockets` property to `1` before starting the Ui server:
+`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option (not just `maxSockets`). [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
+
+Here is an example which uses the `NODE_CONFIG` environment variable to set the `pool` option's `maxSockets` property to `1` prior to starting theIO server:
 ```
 NODE_CONFIG='{"fnApiOptions": {"pool": {"maxSockets": 1}}}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
 ```

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -9,9 +9,9 @@
 ## Configuration using node-config
 
 Some configuration options are specified using [node-config](https://www.npmjs.com/package/config). 
-These are read from a configuration file  `config/default.json` and may be configured by changing that file.
-specifying a different configuraiton file (see the [node-config](https://www.npmjs.com/package/config) documentation for details)
-or by using the `NODE_CONFIG` environment variable.
+These are read from a configuration file  `config/default.json` and may be configured by changing that file,
+by specifying a different configuration file (see the [node-config](https://www.npmjs.com/package/config) documentation for details)
+or by setting the `NODE_CONFIG` environment variable.
 
 Here is `config/default.json`:
 ```
@@ -28,7 +28,7 @@ The following configuration option may be specified this way:
 
 `fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option (not just `maxSockets`). [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
 
-Here is an example which uses the `NODE_CONFIG` environment variable to set the `pool` option's `maxSockets` property to `1` prior to starting theIO server:
+Here is an example which uses the `NODE_CONFIG` environment variable to set the `pool` option's `maxSockets` property to `1` prior to starting the UI server:
 ```
 NODE_CONFIG='{"fnApiOptions": {"pool": {"maxSockets": 1}}}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
 ```

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -26,7 +26,7 @@ Here is `config/default.json`:
 
 The following configuration option may be specified this way:
 
-`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option (not just `maxSockets`). [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
+* `fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option (not just `maxSockets`). [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
 
 Here is an example which uses the `NODE_CONFIG` environment variable to set the `pool` option's `maxSockets` property to `1` prior to starting the UI server:
 ```

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -12,9 +12,9 @@ Configuration options are set in `config/default.json`.
 }
 ```
 
-`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when pooling the Fn server for statistics.
+`fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option. [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
 
-These can be configured by changing `config/default.json` or setting `NODE_CONFIG`. For example, to set `maxSockets` to `1`:
+To specify an option, either modify `config/default.json` or set `NODE_CONFIG`. For example, to set the `pool` option's `maxSockets` property to `1`:
 ```
 NODE_CONFIG='{"fnApiOptions": {"pool": {"maxSockets": 1}}}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
 ```

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -14,7 +14,7 @@ Configuration options are set in `config/default.json`.
 
 `fnApiOptions` is used to specify options that are passed to the [request](https://www.npmjs.com/package/request) function when polling the Fn server for statistics. You can specify any valid request option. [Here is a complete list](https://www.npmjs.com/package/request#requestoptions-callback)
 
-To specify an option, either modify `config/default.json` or set `NODE_CONFIG`. For example, to set the `pool` option's `maxSockets` property to `1`:
+To specify an option, either modify `config/default.json` or set `NODE_CONFIG`. For example, to set the `pool` option's `maxSockets` property to `1` before starting the Ui server:
 ```
 NODE_CONFIG='{"fnApiOptions": {"pool": {"maxSockets": 1}}}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ PORT=4000 FN_API_URL=http://localhost:8080 npm start
 * `PORT` - port to run UI on. Optional, 4000 by default
 * `FN_API_URL` - Functions API URL. Required
 
+See the full [configuration  options](CONFIG.md)
+
 ### 5) View in browser
 
 [http://localhost:4000/](http://localhost:4000/)

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,7 @@
+{
+  "fnApiOptions": {
+    "pool": {
+      "maxSockets": "Infinity"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "FunctionsUI",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2419,6 +2419,15 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
+    },
+    "config": {
+      "version": "1.29.4",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.29.4.tgz",
+      "integrity": "sha1-G0J1LthrNj/EAllgVp/XSXiGKpI=",
+      "requires": {
+        "json5": "0.4.0",
+        "os-homedir": "1.0.2"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -5509,6 +5518,11 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "dev": true
     },
+    "json5": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -6841,6 +6855,11 @@
           }
         }
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "pascalcase": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-runtime": "^6.26.0",
     "body-parser": "^1.15.2",
     "chart.js": "^2.6.0",
+    "config": "^1.29.4",
     "exports-loader": "^0.6.3",
     "express": "~4.13.4",
     "file-loader": "^0.8.5",

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var url = require('url');
 var request = require('request');
+var config = require('config');
 
 exports.extend = function(target) {
     var sources = [].slice.call(arguments, 1);
@@ -24,11 +25,30 @@ exports.getApiEndpoint = function(req, path, params, successcb, errorcb) {
   console.log("GET " + url + ", params: ", params);
 
   options = {url: url, qs: params}
-
+  options = config.util.extendDeep({},options,config.fnApiOptions)
   options = exports.addAuth(options, req)
+  exports.dumpOptions(options);
 
   request(options, function(error, response, body){exports.requestCB(successcb, errorcb, error, response, body)});
 }
+
+exports.dumpOptions = function(options){
+  console.log("Dumping options.......");
+  for (var key1 in options) {
+    if (options.hasOwnProperty(key1)) {
+      var value1 = options[key1];
+      console.log(key1 + " -> " + value1);
+      if (key1!="url"){
+        for (var key2 in value1) {
+          if (value1.hasOwnProperty(key2)) {
+            var value2 = value1[key2];
+            console.log("    "+key2 + " -> " + value2);
+          }
+        }
+      }
+    }
+  }
+} 
 
 exports.postApiEndpoint = function(req, path, params, postfields, successcb, errorcb) {
   exports.execApiEndpoint('POST', req, path, params, postfields, successcb, errorcb);

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -27,28 +27,9 @@ exports.getApiEndpoint = function(req, path, params, successcb, errorcb) {
   options = {url: url, qs: params}
   options = config.util.extendDeep({},options,config.fnApiOptions)
   options = exports.addAuth(options, req)
-  exports.dumpOptions(options);
 
   request(options, function(error, response, body){exports.requestCB(successcb, errorcb, error, response, body)});
 }
-
-exports.dumpOptions = function(options){
-  console.log("Dumping options.......");
-  for (var key1 in options) {
-    if (options.hasOwnProperty(key1)) {
-      var value1 = options[key1];
-      console.log(key1 + " -> " + value1);
-      if (key1!="url"){
-        for (var key2 in value1) {
-          if (value1.hasOwnProperty(key2)) {
-            var value2 = value1[key2];
-            console.log("    "+key2 + " -> " + value2);
-          }
-        }
-      }
-    }
-  }
-} 
 
 exports.postApiEndpoint = function(req, path, params, postfields, successcb, errorcb) {
   exports.execApiEndpoint('POST', req, path, params, postfields, successcb, errorcb);


### PR DESCRIPTION
This PR introduces the [config](https://www.npmjs.com/package/config) module and uses it to allow request options to be specified for when the UI server performs the  `GET` requests to the Fn server.  

See the new `CONFIG.md` file for more information.

(Note that this uses the same config package as the other PR https://github.com/fnproject/ui/pull/44)