### PR TITLE
Fix for #29 deleting app via UI not working

### DIFF
--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -89,9 +89,8 @@
 <script>
 import FnAppForm from '../components/FnAppForm';
 import StatsChart from '../components/StatsChart'
-
-import { defaultErrorHandler } from '../lib/helpers';
 import { eventBus } from '../client';
+import { defaultErrorHandler, getAuthToken } from '../lib/helpers';
 
 export default {
   props: ['apps','stats','statshistory','autorefresh'],


### PR DESCRIPTION
This was just a missing import, which made the delete code fail on the browser.