### PR TITLE
Fetch metrics from /metrics instead of /stats

### DIFF
--- a/server/controllers/stats.js
+++ b/server/controllers/stats.js
@@ -33,9 +33,9 @@ router.get('/', function(req, res) {
     var valueRE = '(\\d+)'             
     
     // allMetricsRE is the complete RE (allowing for more than two labels)
-    var allMetricsRE    = metricNameRE+   '{'+labelRE+'(?:,'+labelRE+')+}'+spacesRE+valueRE;
+    var allMetricsRE    = '^' + metricNameRE + '{'+labelRE+'(?:,'+labelRE+')+}'+spacesRE+valueRE;
 
-    var regex = RegExp(allMetricsRE,'g');
+    var regex = RegExp(allMetricsRE,'gm');
 
     // metricData contains the data extracted from a single line of /metrics data
     var metricData; 

--- a/server/controllers/stats.js
+++ b/server/controllers/stats.js
@@ -1,13 +1,127 @@
 var express = require('express');
 var router = express.Router();
 var helpers = require('../helpers/app-helpers.js');
+var logger = require('config-logger');
 
 router.get('/', function(req, res) {
   successcb = function(data){
-    res.json(data);
+    // convert the raw Prometheus data to JSON in a form usable by the client
+
+    var queuedLabel = 'fn_queued';
+    var runningLabel = 'fn_running';
+    var completedlabel = "fn_completed";
+    var failedLabel = "fn_failed";
+    var appNameMetric = "fn_appname";
+    var pathNameMetric = "fn_path";
+
+    // Construct a RE to extract data from the raw Prometheus metrics data, which will include lines like
+    // fn_completed{fn_appname="hello-cold-async-a",fn_path="/hello-cold-async-a2"} 21
+
+    // metricNameRE matches any of the required metric names, and saves the metric name
+    var metricNameRE = '('+queuedLabel+'|'+runningLabel+'|'+completedlabel+'|'+failedLabel+')'; 
+
+    // labelNameRE matches a label name, which is anything that's not a = (equals sign), and saves the label name
+    var labelNameRE = '([^=]+)';   
+    // labelValueRE matches a label value, which is anything that's not a " (double quote), and save the label value
+    var labelValueRE = '\"([^\"]*)\"'; 
+    // labelRE is a combined label name/value pair
+    var labelRE = labelNameRE+'='+labelValueRE;
+
+    // spacesRE matches one or more spaces
+    var spacesRE = '\\s+';            
+    //  valueRE matches one or more numeric digits, and saves the metric value
+    var valueRE = '(\\d+)'             
+    
+    // allMetricsRE is the complete RE (allowing for more than two labels)
+    var allMetricsRE    = metricNameRE+   '{'+labelRE+'(?:,'+labelRE+')+}'+spacesRE+valueRE;
+
+    var regex = RegExp(allMetricsRE,'g');
+
+    // metricData contains the data extracted from a single line of /metrics data
+    var metricData; 
+    //metricData[0] = the whole line (only used in error messages)
+    //metricData[1] = metric name (one of fn_queued|fn_running|fn_completed|fn_failed)
+    //metricData[2] = fn_appname (identifies the subsequent element)
+    //metricData[3] = app name
+    //metricData[4] = fn_path (identifies the subsequent element)
+    //metricData[5] = path name  
+    //metricData[6] = metric value (integer)
+
+    // jsonData is an object representation of the JSON data that will be returned to the client
+    // See https://github.com/fnproject/fn/pull/735 for an example of the JSON format generated (but we don't bother with the totals)
+    var jsonData = {"Apps":{}}
+   
+    while ((metricData = regex.exec(data)) !== null) {
+      // we have found a single metric value
+
+      if (metricData.length<1){
+        logger.error("Unexpected metrics data");
+        continue;
+      } else if (metricData.length<7){
+        logger.error("Unexpected metrics data: "+metricData[0]);
+        continue;
+      }
+
+      logger.debug("Processing "+metricData[0]);
+
+      // get metric name
+      var metricName = metricData[1];
+
+      // get app name (don't assume order of labels)
+      var appName
+      if (metricData[2]==appNameMetric){
+        appName = metricData[3];
+      } else if (metricData[4]==appNameMetric){
+        appName = metricData[5];
+      } else {
+        logger.error("Unexpected metrics data: "+appNameMetric+" not found in "+metricData[0]);
+        continue;
+      }
+
+      // get path name (don't assume order of labels)
+      var pathName
+      if (metricData[4]==pathNameMetric){
+        pathName = metricData[5];
+      } else if (metricData[2]==pathNameMetric){
+        pathName = metricData[3];
+      } else {
+        logger.error("Unexpected metrics data: "+pathNameMetric+" not found in "+metricData[0]);
+        continue;
+      }
+
+      // get metric value
+      var metricValue = parseInt(metricData[6]);
+
+      // add to jsonData
+      if (jsonData.Apps[appName]==null){
+        jsonData.Apps[appName] = {"Routes":{}};
+      }
+      if (jsonData.Apps[appName].Routes[pathName]==null){
+        jsonData.Apps[appName].Routes[pathName]={"Queue":0,"Running":0,"Complete":0,"Failed":0};
+      }
+      switch (metricName){
+        case queuedLabel:
+        jsonData.Apps[appName].Routes[pathName].Queue=metricValue;
+        break;
+        case runningLabel:
+        jsonData.Apps[appName].Routes[pathName].Running=metricValue;
+        break;
+        case completedlabel:
+        jsonData.Apps[appName].Routes[pathName].Complete=metricValue;
+        break;
+        case failedLabel:
+        jsonData.Apps[appName].Routes[pathName].Failed=metricValue;
+        break;                        
+      }
+    }
+
+    res.json(jsonData);
   }
 
-  helpers.getApiEndpoint(req, "/stats", {}, successcb, helpers.standardErrorcb(res))
+  // get the raw Prometheus data
+  helpers.getApiEndpointRaw(req, "/metrics", {}, successcb, helpers.standardErrorcb(res))
+
 });
+
 
 module.exports = router;

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -31,6 +31,18 @@ exports.getApiEndpoint = function(req, path, params, successcb, errorcb) {
   request(options, function(error, response, body){exports.requestCB(successcb, errorcb, error, response, body)});
 }
 
+exports.getApiEndpointRaw = function(req, path, params, successcb, errorcb) {
+  var url = exports.apiFullUrl(req, path);
+
+  logger.debug("GET " + url + ", params: ", params);
+
+  options = {url: url, qs: params}
+
+  options = exports.addAuth(options, req)
+
+  request(options, function(error, response, body){exports.requestCBRaw(successcb, errorcb, error, response, body)});
+}
+
 exports.postApiEndpoint = function(req, path, params, postfields, successcb, errorcb) {
   exports.execApiEndpoint('POST', req, path, params, postfields, successcb, errorcb);
 }


### PR DESCRIPTION
This PR changes the UI server so that instead of fetching metrics data from the Fn server's `/stats` endpoint, it fetches them directly from the Fn server's `/metrics` endpoint, which is implemented by the Prometheus client running in the Fn server.

Readers will remember that the UI client currently polls the UI server's `/api/stats` endpoint, which in turn polls the Fn server's `/stats` endpoint. 

With these changes, the UI client continues to poll the UI server's `/api/stats` endpoint as now, and receives metrics data in the same convenient JSON format as now. 

However when the UI server receives a request on `/api/stats` it now polls the Fn server's `/metrics` endpoint. This returns the same data in a different format defined by Prometheus. The UI server parses this data using a single regular expression, builds a JSON structure containing this data, and passes it on to the client.

This keeps the regular expression parsing on the server, thereby avoiding increasing the load on the client. However it's just standard Javascript and would be easy to move to the client if we wanted to in the future. 

The actual parsing code comes out fairly nicely, though I have added lots of comments and intermediate variables to make it easy to understand and change if needed.