### PR TITLE
Add the webpack version to the dev instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm install webpack -g
+RUN npm install -g webpack@^1.14.0
 COPY package.json /app
 RUN npm install
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All functions in an app:
 
 ```sh
 npm install
-sudo npm install -g webpack
+sudo npm install -g webpack@^1.14.0
 ```
 
 ### 2) Start Functions API (see [Fn on GitHub](http://github.com/fnproject/fn))


### PR DESCRIPTION
Following the current dev setup instructions causes the latest version of webpack to be installed. However, The code doesn't currently support this which causes various errors (c.f. #55).

For now, update the instructions so anyone following them will install a version that the UI works with so they don't need to waste time trying to get their setup working.

Later on we can look at getting the dependencies updated and the UI working with the latest version of webpack.