### PR TITLE
Update Apps to use V2 API

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -23,7 +23,7 @@ const numXValues = 50;
 const router = new VueRouter({
   routes: [
     { path: '/', component: IndexPage },
-    { path: '/app/:appname', component: AppPage }
+    { path: '/app/:appid', component: AppPage }
   ]
 });
 

--- a/client/components/FnAppForm.vue
+++ b/client/components/FnAppForm.vue
@@ -79,14 +79,14 @@ export default {
       eventBus.$emit('NotificationClear');
       this.app.config = linesToConfig(this.appConfig);
       if (this.edit) {
-        var url = '/api/apps/' + encodeURIComponent(this.app.name);
+        var url = '/api/apps/' + encodeURIComponent(this.app.id);
       } else {
         var url = '/api/apps';
       };
       $.ajax({
         headers: {'Authorization': getAuthToken()},
         url: url,
-        method: this.edit ? 'PATCH' : 'POST',
+        method: this.edit ? 'PUT' : 'POST',
         data: JSON.stringify(this.app),
         contentType: "application/json",
         dataType: 'json',

--- a/client/components/FnSidebar.vue
+++ b/client/components/FnSidebar.vue
@@ -18,10 +18,10 @@
 </div>
 
     <ul class="nav nav-sidebar" v-if="app">
-      <li :class="{active: app && app.name == a.name}"  v-for="a in apps">
-        <router-link :to="'/app/' + encodeURIComponent(a.name)">
+      <li :class="{active: app && app.id == a.id}"  v-for="a in apps">
+        <router-link :to="'/app/' + encodeURIComponent(a.id)">
           {{a.name}}
-          <span class="sr-only" v-if="app && app.name == a.name">(current)</span>
+          <span class="sr-only" v-if="app && app.id== a.id">(current)</span>
         </router-link>
       </li>
     </ul>

--- a/client/pages/AppPage.vue
+++ b/client/pages/AppPage.vue
@@ -185,7 +185,7 @@ export default {
       eventBus.$emit('AppOpened', this.app);
     },
     appSwitched: function(){
-      this.loadApp(this.$route.params.appname, () => { this.appLoaded(); });
+      this.loadApp(this.$route.params.appid, () => { this.appLoaded(); });
     }
   },
   watch: {
@@ -195,10 +195,10 @@ export default {
     // access to component instance via `vm`
     next(vm => {
       if (vm.apps){
-        vm.app = _.find(vm.apps, (app) => {return app.name == to.params.appname});
+        vm.app = _.find(vm.apps, (app) => {return app.id == to.params.appid});
         vm.appLoaded();
       } else {
-        vm.loadApp(to.params.appname, () => { vm.appLoaded(); });
+        vm.loadApp(to.params.appid, () => { vm.appLoaded(); });
       }
     })
   },

--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -30,7 +30,7 @@
             <tbody>
               <tr v-for="app in apps">
                 <td>
-                  <router-link :to="'/app/' + encodeURIComponent(app.name)">{{app.name}}</router-link>
+                  <router-link :to="'/app/' + encodeURIComponent(app.id)">{{app.name}}</router-link>
                 </td>
                 <td>
                   <div class="toolbar">
@@ -122,7 +122,7 @@ export default {
         var t = this;
         $.ajax({
           headers: {'Authorization': getAuthToken()},
-          url: '/api/apps/' + encodeURIComponent(app.name),
+          url: '/api/apps/' + encodeURIComponent(app.id),
           method: 'DELETE',
           dataType: 'json',
           success: (app) => { eventBus.$emit('AppDeleted', app) },

--- a/server/controllers/apps.js
+++ b/server/controllers/apps.js
@@ -4,18 +4,17 @@ var helpers = require('../helpers/app-helpers.js');
 
 router.get('/', function(req, res) {
   successcb = function(data){
-    res.json(data.apps);
+    res.json(data.items);
   }
-
-  helpers.getApiEndpoint(req, "/v1/apps", {}, successcb, helpers.standardErrorcb(res))
+  helpers.getApiEndpoint(req, "/v2/apps", {}, successcb, helpers.standardErrorcb(res))
 });
 
 router.get('/:app', function(req, res) {
   successcb = function(data){
-    res.json(data.app);
+    res.json(data);
   }
 
-  helpers.getApiEndpoint(req, "/v1/apps/" + encodeURIComponent(req.params.app), {}, successcb, helpers.standardErrorcb(res))
+  helpers.getApiEndpoint(req, "/v2/apps/" + encodeURIComponent(req.params.app), {}, successcb, helpers.standardErrorcb(res))
 });
 
 // Create New App
@@ -25,19 +24,22 @@ router.post('/', function(req, res) {
   }
   var data = req.body;
 
-  helpers.postApiEndpoint(req, "/v1/apps", {}, {app: data}, successcb, helpers.standardErrorcb(res));
+  helpers.postApiEndpoint(req, "/v2/apps", {}, data, successcb, helpers.standardErrorcb(res));
 });
 
 // Update App
-router.patch('/:app', function(req, res) {
+router.put('/:app', function(req, res) {
   successcb = function(data){
     res.json(data);
   }
 
   var data = req.body;
+  delete data.id;
   delete data.name;
+  delete data.created_at;
+  delete data.updated_at;
 
-  helpers.execApiEndpoint('PATCH', req,  "/v1/apps/" + encodeURIComponent(req.params.app) , {}, {app: data}, successcb, helpers.standardErrorcb(res));
+  helpers.execApiEndpoint('PUT', req,  "/v2/apps/" + encodeURIComponent(req.params.app) , {}, data, successcb, helpers.standardErrorcb(res));
 });
 
 // Delete App
@@ -46,7 +48,7 @@ router.delete('/:app', function(req, res) {
     res.json(data);
   }
 
-  helpers.execApiEndpoint('DELETE', req,  "/v1/apps/" + encodeURIComponent(req.params.app) , {}, {}, successcb, helpers.standardErrorcb(res));
+  helpers.execApiEndpoint('DELETE', req,  "/v2/apps/" + encodeURIComponent(req.params.app) , {}, {}, successcb, helpers.standardErrorcb(res));
 });
 
 

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -97,6 +97,14 @@ exports.requestCB = function (successcb, errorcb, error, response, body) {
     } catch (e) {
       console.warn("Can not parse json:", body, e);
     };
+
+    // A 204 status code indicates a success but there won't be any data. E.g.
+    // on the deletion of an app. This will throw an error down the line so
+    // initialise parsed.
+    if (!parsed && response.statusCode == 204) {
+      parsed = {};
+    }
+
     if (parsed){
       successcb(parsed);
     } else {


### PR DESCRIPTION
The V1 Fn Server API is no longer supported. Therefore, make a start on migrating the UI over to the V2 API. This commit migrates the App functionality over and means users can now add/delete/edit apps.

This contributes to: #52, fnproject/fn#1347, fnproject/fn_go#31, and fnproject/fn#1258.

There's still lots to do, but I want to keep the PRs small and easy to review.