### PR TITLE
Fix broken links

### DIFF
--- a/client/components/FnSidebar.vue
+++ b/client/components/FnSidebar.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
 
-    <a class="navbar-brand" href="#">
+    <router-link class="navbar-brand" to="/">
         <!-- See also banner for small devices in index.html -->
         <img class="navbar-brand" src="/images/icons/fn_transparent.png">
-    </a>
+    </router-link>
     <div>
     <div v-if="!loggedIn">
         <button type="button" class="btn btn-default" @click='login' :disabled="loggingin">

--- a/client/components/FnWelcomeSection.vue
+++ b/client/components/FnWelcomeSection.vue
@@ -15,7 +15,7 @@
           <i class="fa fa-bolt"></i> Quick Start
         </a>
       </li>
-      <li><a href="http://petstore.swagger.io/?url=https://raw.githubusercontent.com/fnproject/fn/master/docs/swagger.yml" target="_blank">
+      <li><a href="http://petstore.swagger.io/?url=https://raw.githubusercontent.com/fnproject/fn/master/docs/swagger_v2.yml" target="_blank">
         <i class="fa fa-file-text-o"></i> Fn API</a>
       </li>
       <li>


### PR DESCRIPTION
This fixes:

> * Link to the new FN API docs.
> * Fix FN Logo homepage link - it's not going back to the home page.

As mentioned in #52.

To test:
* Click the `FN API` link in the side bar and it should go to the correct Swagger URL
* Click the Fn Logo when looking at an App and it should take you back to the home page