### PR TITLE
Add support for modifying the syslog url

### DIFF
--- a/client/components/FnAppForm.vue
+++ b/client/components/FnAppForm.vue
@@ -2,9 +2,15 @@
   <modal :title="title()" :show="show" @closed="closed" @ok="ok" @cancel="closed">
     <form class="form-horizontal" v-on:submit.prevent="ok">
       <div class="form-group">
-        <label class="col-sm-3 control-label">Name</label>
+        <label class="col-sm-3 control-label">Name *</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" placeholder="e.g. my-app" v-model="app.name" required :disabled="edit" @keydown.enter.prevent="">
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="col-sm-3 control-label">Syslog URL</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" placeholder="e.g. tcp://syslogserver.local"  v-model="app.syslog_url" @keydown.enter.prevent="">
         </div>
       </div>
 

--- a/server/helpers/app-helpers.js
+++ b/server/helpers/app-helpers.js
@@ -118,8 +118,12 @@ exports.requestCB = function (successcb, errorcb, error, response, body) {
       } else {
         parsed = body;
       }
-      if (parsed && parsed.error && parsed.error.message){
-        message = parsed.error.message;
+      if (parsed) {
+        if(parsed.error && parsed.error.message){
+          message = parsed.error.message;
+        } else if(parsed.message){
+          message = parsed.message;
+        }
       }
     } catch (e) {
       message = "Can not parse api response";


### PR DESCRIPTION
This PR adds the ability to add/modify the `syslog_url` for apps as per #52. I also noticed that the error messages weren't showing correctly when I tried adding a syslog url which didn't start with a supported scheme so have also fixed this.

I've kept in support for error messages that might use `parsed.error.message` in case anything else uses it.

To test the syslog URL changes:
* Add an app with a syslog_url
* Check the syslog URL is correct using `fn inspect app $appName`
* Edit the syslog URL and check it had been correctly modified using `fn inspect app`

To test the error message changes:
* Try adding an app with an invalid scheme e.g. `this-is-invalid.local`
* Try adding an app with the same name as another app