### PR TITLE
Fix deletion of configs

### DIFF
--- a/client/components/FnAppForm.vue
+++ b/client/components/FnAppForm.vue
@@ -9,28 +9,7 @@
       </div>
 
       <hr>
-
-      <div class="form-group">
-        <label class="col-sm-3 control-label">Config</label>
-        <div class="col-sm-9">
-          <div class="row" v-for="(line, index) in appConfig">
-            <div class="col-sm-5 cfg-key">
-              <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
-            </div>
-            <div class="col-sm-5 cfg-val">
-              <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
-            </div>
-            <div class="col-sm-1 toolbar">
-              <button class="btn btn-default" @click.prevent="removeConfigLine(index)"><i class="fa fa-times"></i></button>
-            </div>
-          </div>
-          <div>
-            <a href="#" class="" @click.prevent="addConfigLine">
-              <i class="fa fa-plus"></i> Add line
-            </a>
-          </div>
-        </div>
-      </div>
+      <fn-config-form :config="appConfig"></fn-config-form>
 
     </form>
 
@@ -42,13 +21,15 @@
 
 <script>
 import Modal from '../lib/VueBootstrapModal.vue';
+import FnConfigForm from '../components/FnConfigForm';
 import { eventBus } from '../client';
 import { defaultErrorHandler, configToLines, linesToConfig, getAuthToken } from '../lib/helpers';
 
 export default {
   props: [],
   components: {
-    Modal
+    Modal,
+    FnConfigForm,
   },
   data: function(){
     return {
@@ -119,14 +100,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.cfg-key {
-  padding: 0 5px 5px 15px;
-}
-.cfg-val {
-  padding: 0 5px 5px 5px;
-  margin-right: -20px;
-  width: 50%;
-}
-</style>

--- a/client/components/FnConfigForm.vue
+++ b/client/components/FnConfigForm.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="form-group">
+    <label class="col-sm-3 control-label">Config</label>
+    <div class="col-sm-9">
+      <div class="row" v-for="(line, index) in config">
+        <template v-if="!line.delete">
+          <div class="col-sm-5 cfg-key">
+            <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
+          </div>
+          <div class="col-sm-5 cfg-val">
+            <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
+          </div>
+          <div class="col-sm-1 toolbar">
+            <button class="btn btn-default" @click.prevent="removeConfigLine(index)"><i class="fa fa-times"></i></button>
+          </div>
+        </template>
+      </div>
+      <div>
+        <a href="#" class="" @click.prevent="addConfigLine">
+          <i class="fa fa-plus"></i> Add line
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['config'],
+  methods: {
+    addConfigLine: function(){
+      this.config.push({key: "", value: "", delete: false});
+    },
+    removeConfigLine: function(index){
+      // The entry needs to exist to distinguish between deletion and not
+      // updating it. Therefore, set the value to empty and hide it
+      this.config[index].value = "";
+      this.config[index].delete = true;
+    },
+  }
+}
+</script>
+
+<style scoped>
+.cfg-key {
+  padding: 0 5px 5px 15px;
+}
+.cfg-val {
+  padding: 0 5px 5px 5px;
+  margin-right: -20px;
+  width: 50%;
+}
+</style>

--- a/client/components/FnFunctionForm.vue
+++ b/client/components/FnFunctionForm.vue
@@ -39,15 +39,17 @@
         <label class="col-sm-3 control-label">Config</label>
         <div class="col-sm-9">
           <div class="row" v-for="(line, index) in fnConfig">
-            <div class="col-sm-5 cfg-key">
-              <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
-            </div>
-            <div class="col-sm-5 cfg-val">
-              <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
-            </div>
-            <div class="col-sm-1 toolbar">
-              <button class="btn btn-default" @click.prevent="removeConfigLine(index)"><i class="fa fa-times"></i></button>
-            </div>
+            <template v-if="!line.delete">
+              <div class="col-sm-5 cfg-key">
+                <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
+              </div>
+              <div class="col-sm-5 cfg-val">
+                <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
+              </div>
+              <div class="col-sm-1 toolbar">
+                <button class="btn btn-default" @click.prevent="removeConfigLine(index)"><i class="fa fa-times"></i></button>
+              </div>
+            </template>
           </div>
           <div>
             <a href="#" class="" @click.prevent="addConfigLine">
@@ -104,10 +106,13 @@ export default {
       this.show = false;
     },
     addConfigLine: function(){
-      this.fnConfig.push({key: "", value: ""});
+      this.fnConfig.push({key: "", value: "", delete: false});
     },
     removeConfigLine: function(index){
-      this.fnConfig.splice(index, 1)
+      // The entry needs to exist to distinguish between deletion and not
+      // updating it. Therefore, set the value to empty and hide it
+      this.fnConfig[index].value = "";
+      this.fnConfig[index].delete = true;
     },
     ok: function(){
       var t = this;

--- a/client/components/FnFunctionForm.vue
+++ b/client/components/FnFunctionForm.vue
@@ -34,30 +34,7 @@
       </div>
 
       <hr>
-
-      <div class="form-group">
-        <label class="col-sm-3 control-label">Config</label>
-        <div class="col-sm-9">
-          <div class="row" v-for="(line, index) in fnConfig">
-            <template v-if="!line.delete">
-              <div class="col-sm-5 cfg-key">
-                <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
-              </div>
-              <div class="col-sm-5 cfg-val">
-                <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
-              </div>
-              <div class="col-sm-1 toolbar">
-                <button class="btn btn-default" @click.prevent="removeConfigLine(index)"><i class="fa fa-times"></i></button>
-              </div>
-            </template>
-          </div>
-          <div>
-            <a href="#" class="" @click.prevent="addConfigLine">
-              <i class="fa fa-plus"></i> Add line
-            </a>
-          </div>
-        </div>
-      </div>
+      <fn-config-form :config="fnConfig"></fn-config-form>
 
     </form>
 
@@ -69,6 +46,7 @@
 
 <script>
 import Modal from '../lib/VueBootstrapModal.vue';
+import FnConfigForm from '../components/FnConfigForm';
 import { eventBus } from '../client';
 import { defaultErrorHandler, configToLines, linesToConfig, headersToLines, linesToHeaders, getAuthToken } from '../lib/helpers';
 
@@ -84,7 +62,8 @@ var defaultFn = function(app){
 export default {
   props: ['app'],
   components: {
-    Modal
+    Modal,
+    FnConfigForm,
   },
   data: function(){
     return {
@@ -104,15 +83,6 @@ export default {
     },
     closed: function(){
       this.show = false;
-    },
-    addConfigLine: function(){
-      this.fnConfig.push({key: "", value: "", delete: false});
-    },
-    removeConfigLine: function(index){
-      // The entry needs to exist to distinguish between deletion and not
-      // updating it. Therefore, set the value to empty and hide it
-      this.fnConfig[index].value = "";
-      this.fnConfig[index].delete = true;
     },
     ok: function(){
       var t = this;
@@ -165,14 +135,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.cfg-key {
-  padding: 0 5px 5px 15px;
-}
-.cfg-val {
-  padding: 0 5px 5px 5px;
-  margin-right: -20px;
-  width: 50%;
-}
-</style>


### PR DESCRIPTION
Prior to this PR if you used the `X` button to delete a config for an app or function (as the interface intends) then it wouldn't make any changes. This is because the config data isn't included in the `PUT` request so the API doesn't think it's been changed. The correct way of deleting a config with the new V2 API is to set its value to an empty string. I have changed the code so it does this behind the scenes, whilst keeping the frontend appearance the same.

I have also separated the config logic into its own Vue component and shared it between apps and functions to remove the duplicated code.

To test:
* Create an app with some config values
* Use the delete button to delete some config values
* Check using the UI or `fn inspect` that the config has been updated accordingly

I have also tested deleting a config and then adding it back prior to clicking submit and this works correctly.

This PR contributes to #52 