### PR TITLE
Fix stylelint deprecation warnings (#64)

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   "rules": {
     "at-rule-empty-line-before": [ "always", {
-      except: [ "blockless-group", "first-nested" ],
+      except: [ "blockless-after-blockless", "first-nested" ],
       ignore: ["after-comment"],
     } ],
     "at-rule-name-case": "lower",
@@ -24,7 +24,6 @@ module.exports = {
     "comment-whitespace-inside": "always",
     "declaration-bang-space-after": "never",
     "declaration-bang-space-before": "always",
-    "declaration-block-no-ignored-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-semicolon-space-after": "always-single-line",
@@ -50,7 +49,6 @@ module.exports = {
     "max-empty-lines": 1,
     "media-feature-colon-space-after": "always",
     "media-feature-colon-space-before": "never",
-    "media-feature-no-missing-punctuation": true,
     "media-feature-range-operator-space-after": "always",
     "media-feature-range-operator-space-before": "always",
     "media-query-list-comma-newline-after": "always-multi-line",
@@ -64,7 +62,7 @@ module.exports = {
     "number-leading-zero": "never",
     "number-no-trailing-zeros": true,
     "property-case": "lower",
-    "rule-non-nested-empty-line-before": [ "always-multi-line", {
+    "rule-empty-line-before": [ "always-multi-line", {
       ignore: ["after-comment"],
     } ],
     "selector-attribute-brackets-space-inside": "never",


### PR DESCRIPTION
This commit removes the deprecation warnings when you run `webpack`. See #64 for more details.

### To test
Run webpack and you shouldn't see any deprecation warnings. Give the interface a quick test to check everything is working as intended