### PR TITLE
Fix bug when editing config keys (#66)

### DIFF
--- a/client/components/FnAppForm.vue
+++ b/client/components/FnAppForm.vue
@@ -15,7 +15,7 @@
       </div>
 
       <hr>
-      <fn-config-form :config="appConfig"></fn-config-form>
+      <fn-config-form :config="appConfig" :isEdit="edit"></fn-config-form>
 
     </form>
 
@@ -29,7 +29,10 @@
 import Modal from '../lib/VueBootstrapModal.vue';
 import FnConfigForm from '../components/FnConfigForm';
 import { eventBus } from '../client';
-import { defaultErrorHandler, configToLines, linesToConfig, getAuthToken } from '../lib/helpers';
+import {
+  defaultErrorHandler, configToLines, linesToConfig, newConfig,
+  getAuthToken
+} from '../lib/helpers';
 
 export default {
   props: [],
@@ -42,7 +45,7 @@ export default {
       show: false,
       edit: false,
       app: {},
-      appConfig: [{key: "", value: ""}]
+      appConfig: [newConfig()]
     }
   },
   methods: {
@@ -56,7 +59,7 @@ export default {
       this.show = false;
     },
     addConfigLine: function(){
-      this.appConfig.push({key: "", value: ""});
+      this.appConfig.push(newConfig());
     },
     removeConfigLine: function(index){
       this.appConfig.splice(index, 1)

--- a/client/components/FnConfigForm.vue
+++ b/client/components/FnConfigForm.vue
@@ -5,7 +5,8 @@
       <div class="row" v-for="(line, index) in config">
         <template v-if="!line.delete">
           <div class="col-sm-5 cfg-key">
-            <input type="text" class="form-control" placeholder="Key" v-model="line.key" @keydown.enter.prevent="">
+            <!-- Don't allow the key to be edited if the form is being edited (providing it hasn't just been added (see issue #66)) -->
+            <input type="text" class="form-control" placeholder="Key" v-model="line.key" :readonly="isEdit && !line.new" @keydown.enter.prevent="">
           </div>
           <div class="col-sm-5 cfg-val">
             <input type="text" class="form-control" placeholder="Value" v-model="line.value" @keydown.enter.prevent="">
@@ -25,11 +26,13 @@
 </template>
 
 <script>
+import { newConfig } from '../lib/helpers';
+
 export default {
-  props: ['config'],
+  props: ['config', 'isEdit'],
   methods: {
     addConfigLine: function(){
-      this.config.push({key: "", value: "", delete: false});
+      this.config.push(newConfig());
     },
     removeConfigLine: function(index){
       // The entry needs to exist to distinguish between deletion and not

--- a/client/components/FnFunctionForm.vue
+++ b/client/components/FnFunctionForm.vue
@@ -34,7 +34,7 @@
       </div>
 
       <hr>
-      <fn-config-form :config="fnConfig"></fn-config-form>
+      <fn-config-form :config="fnConfig" :isEdit="edit"></fn-config-form>
 
     </form>
 
@@ -48,7 +48,10 @@
 import Modal from '../lib/VueBootstrapModal.vue';
 import FnConfigForm from '../components/FnConfigForm';
 import { eventBus } from '../client';
-import { defaultErrorHandler, configToLines, linesToConfig, headersToLines, linesToHeaders, getAuthToken } from '../lib/helpers';
+import {
+  defaultErrorHandler, configToLines, linesToConfig, newConfig,
+  headersToLines, linesToHeaders, getAuthToken
+} from '../lib/helpers';
 
 var defaultFn = function(app){
   return jQuery.extend(true, {}, {
@@ -128,7 +131,7 @@ export default {
     });
     eventBus.$on('openAddFn', () => {
       this.fn = defaultFn(this.app);
-      this.fnConfig = [{key: "", value: ""}];
+      this.fnConfig = [newConfig()];
       this.edit = false;
       this.show = true;
     });

--- a/client/lib/helpers.js
+++ b/client/lib/helpers.js
@@ -22,7 +22,7 @@ export const configToLines = function(config){
   };
   // Always show at least one empty line
   if (lines.length == 0) {
-    lines.push({key: "", value: ""})
+    lines.push(newConfig())
   }
   return lines;
 }
@@ -36,6 +36,14 @@ export const linesToConfig = function(lines){
     }
   }
   return config;
+}
+
+// Initialises and returns an empty config object
+export const newConfig = function() {
+  // 'delete' indicates when this config should be deleted from the server.
+  // 'new' indicates that this config value has just been added and means the
+  // key should be editable on the UI.
+  return {key: "", value: "", delete: false, new: true};
 }
 
 export const headersToLines = function(headers){


### PR DESCRIPTION
There is a bug which means that when a config key is edited a new config is added but the old config isn't deleted (see #66). 

I have implement the first (and easiest) option from https://github.com/fnproject/ui/issues/66#issuecomment-487006837 which makes the config keys readonly so that it forces the user to delete the old config line and add a new one rather than editing an existing config line which will cause issues.

### To Test
Repeat the process described in the issue:

Create an app using the UI e.g.:
```
vzarola-Mac:testing vzarola$ fn inspect app ui-app
{
	"config": {
		"config_key_1": "value"
	},
	"created_at": "2019-04-26T12:06:29.825Z",
	"id": "01D9CRMC61NG8G00GZJ000000Z",
	"name": "ui-app",
	"updated_at": "2019-04-26T12:06:44.430Z"
}
```

Then click the edit app button and try to edit the config's key. The interface won't let you:

![Screen Shot 2019-04-26 at 13 08 02](https://user-images.githubusercontent.com/49067415/56806624-5bd04d00-6824-11e9-9605-272d74fe1290.png)

However, you can still delete that config and add a new config.

I've also tested:
* Creating an app with no configs set then editing it
* Adding new config values whilst editing an app
* Adding a config with the same key as one that is read only (it updates the config key to use the new value)
* Delete a config and add a new one at the same time
* Deleting all configs

Repeat the above this for function configs.