### PR TITLE
Add linting step to CircleCI Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: "Lint the code"
           command: |
-            npm install --only dev
+            npm install --loglevel error --only dev
             ./node_modules/.bin/eslint .
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,6 @@ version: 2
 jobs:
   build:
     machine: true
-    working_directory: ~/go/src/github.com/fnproject/ui
-    environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
-      - GOPATH=/home/circleci/go
-      - GOVERSION=1.8.3
-      - OS=linux
-      - ARCH=amd64
     steps:
       - checkout
       # update Docker
@@ -16,7 +10,6 @@ jobs:
           sudo service docker stop
           curl -fsSL https://get.docker.com/ | sudo sh
       - run: docker version
-      # - run: ./test.sh
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,12 @@ jobs:
       - run:
           name: "Update Docker"
           command: |
-            docker version
-            sudo service docker stop
-            curl -fsSL https://get.docker.com/ | sudo sh
+            # There's need to update docker if we aren't deploying
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker version
+              sudo service docker stop
+              curl -fsSL https://get.docker.com/ | sudo sh
+            fi
       - run: docker version
 
       # Clean up after linting and testing e.g. remove node_modules/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,31 @@ jobs:
     machine: true
     steps:
       - checkout
-      # update Docker
-      - run: |
-          docker version
-          sudo service docker stop
-          curl -fsSL https://get.docker.com/ | sudo sh
+
+      - run:
+          name: "Lint the code"
+          command: |
+            npm install --only dev
+            ./node_modules/.bin/eslint .
+
+      - run:
+          name: "Update Docker"
+          command: |
+            docker version
+            sudo service docker stop
+            curl -fsSL https://get.docker.com/ | sudo sh
       - run: docker version
+
+      # Clean up after linting and testing e.g. remove node_modules/
+      # so test packages aren't included in any production images
       - deploy:
+          name: "Clean up linting and test files"
+          command: |
+            git clean -fxd
+            git reset --hard
+
+      - deploy:
+          name: "Build docker image and release"
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS


### PR DESCRIPTION
## About
I recently added some basic linting (c.f. #69). This commit incorporates this linting into the CircleCI pipeline so CircleCI will fail if the linting fails.

Originally I tried using `npm install eslint` in the lint step in a hope to only install eslint rather than everything that is needed for the UI to work. However, I noticed this was still installing all the packages in `package.json` so thought I might as well just use the eslint version from the `package.json` file rather than ending up with a version mismatch. This does mean it installs the other dev dependencies though which adds about 20-30 seconds to the CircleCI build. I hope this isn't an issue - I'm not sure how CircleCI pricing works for fn and if this would add unnecessary costs. I've limited it to only the dev dependencies to try and reduce the amount that is installed. However, if I ever get around to adding unit tests we'll be installing all these dependencies anyway.

## Testing
To test this I setup my own CircleCI and Docker hub account. Set the docker hub credentials in my CircleCI account accordingly and updated the code so it pushed to my docker hub repo rather than fn: https://github.com/vzDevelopment/ui/commit/7746089ea8113721445f4aa54d36ed7b258f6c7c.

I then ran a UI using the built image with `docker run --rm -it --link fnserver:api -p 4000:4000 -e "FN_API_URL=http://api:8080" odev/uitest`

After I confirmed this was all working, I made a commit that caused a linting issue (https://github.com/vzDevelopment/ui/commit/27f8c8283de62fd502253207775e662767269db8) and watched CircleCI fail.

I've dropped these commits in the branch that I am using in the PR so they don't pollute the git history.