### PR TITLE
Add Selenium Integration Tests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,12 @@ parserOptions:
   ecmaVersion: 2018
   sourceType: module
 plugins:
+  - mocha
   - vue
 rules:
   semi: ['warn', 'always']
+
+  # Mocha plugin rules
+  mocha/no-exclusive-tests: ['error']
+  mocha/no-identical-title: ['error']
+  mocha/no-skipped-tests: ['error']

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,7 @@ env:
   es6: true
   node: true
   jquery: true
+  mocha: true
 extends:
   - 'eslint:recommended'
   - 'plugin:vue/essential'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ All functions in an app:
 
 ## Development
 
-### 1) Install dependencies
+### Setup
+
+#### 1) Install dependencies
 
 ```sh
 npm install
@@ -35,13 +37,13 @@ npm install
 sudo npm install -g webpack@^1.14.0
 ```
 
-### 2) Start Functions API (see [Fn on GitHub](http://github.com/fnproject/fn))
+#### 2) Start Functions API (see [Fn on GitHub](http://github.com/fnproject/fn))
 
 ```sh
 fn start
 ```
 
-### 4) Compile assets
+#### 3) Compile assets
 
 ```sh
 # option 1: if global webpack
@@ -51,7 +53,7 @@ webpack
 npx webpack
 ```
 
-### 3) Start web server
+#### 4) Start web server
 
 ```sh
 PORT=4000 FN_API_URL=http://localhost:8080 npm start
@@ -60,15 +62,40 @@ PORT=4000 FN_API_URL=http://localhost:8080 npm start
 * `PORT` - port to run UI on. Optional, 4000 by default
 * `FN_API_URL` - Functions API URL. Required
 
-### 5) View in browser
+#### 5) View in browser
 
 [http://localhost:4000/](http://localhost:4000/)
 
-### Configuring log levels
+#### Configuring log levels
 
 UI uses [console-logging](https://www.npmjs.com/package/config-logger) for server-side logging. 
 This supports log levels of `debug`, `verbose`, `info`, `warn` and `error`. By default the log level is `info` (this is configured in `config/default.json`). To set a log level of `debug`, use
+
 ```
 NODE_CONFIG='{"logLevel":"debug"}' PORT=4000 FN_API_URL=http://localhost:8080 npm start
 
+```
+
+### Automated Testing
+#### Integration tests
+
+The Fn UI has some basic Selenium integration tests that can be used to automatically test the UI's core functionality. These tests use the `mocha` testing framework as the driver.
+
+To run the tests:
+
+##### 1) Install the Chrome Driver
+Download the ChromeDriver from [Google](https://sites.google.com/a/chromium.org/chromedriver/downloads) and put it in a place which is in your path e.g. `/usr/local/bin/chromedriver`.
+
+##### 2) Install the Node dev dependencies
+Ensure you have the Node dev dependencies installed with:
+```
+npm install [--only dev]
+```
+
+##### 3) Run the Fn interface
+See the instructions above for how to start the Node webserver.
+
+##### 4) Run the tests
+```
+npm run test-integration
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ npm install [--only dev]
 ##### 3) Run the Fn interface
 See the instructions above for how to start the Node webserver.
 
-##### 4) Run the tests
+##### 4) Configure your tests
+Edit [test_integration/etc/config.yaml](test_integration/etc/config.yaml) accordingly e.g. point `fn_url` to your Fn UI if you're not running it at its default location.
+
+##### 5) Run the tests
 ```
 npm run test-integration
 ```

--- a/client/components/FnAppForm.vue
+++ b/client/components/FnAppForm.vue
@@ -1,16 +1,16 @@
 <template>
   <modal :title="title()" :show="show" @closed="closed" @ok="ok" @cancel="closed">
-    <form class="form-horizontal" v-on:submit.prevent="ok">
+    <form id="appForm" class="form-horizontal" v-on:submit.prevent="ok">
       <div class="form-group">
         <label class="col-sm-3 control-label">Name *</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" placeholder="e.g. my-app" v-model="app.name" required :disabled="edit" @keydown.enter.prevent="">
+          <input id="appName" type="text" class="form-control" placeholder="e.g. my-app" v-model="app.name" required :disabled="edit" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Syslog URL</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" placeholder="e.g. tcp://syslogserver.local"  v-model="app.syslog_url" @keydown.enter.prevent="">
+          <input id="appSyslogUrl" type="text" class="form-control" placeholder="e.g. tcp://syslogserver.local"  v-model="app.syslog_url" @keydown.enter.prevent="">
         </div>
       </div>
 
@@ -20,7 +20,7 @@
     </form>
 
     <div slot="footer">
-      <button type="button" class="btn btn-primary" @click="ok">{{okBtnName()}}</button>
+      <button id="submitApp" type="button" class="btn btn-primary" @click="ok">{{okBtnName()}}</button>
     </div>
   </modal>
 </template>

--- a/client/components/FnFunctionForm.vue
+++ b/client/components/FnFunctionForm.vue
@@ -1,35 +1,35 @@
 <template>
   <modal :title="title()" :show="show" @closed="closed" @ok="ok" @cancel="closed">
-    <form class="form-horizontal" v-on:submit.prevent="ok">
+    <form id="fnForm" class="form-horizontal" v-on:submit.prevent="ok">
       <div class="form-group">
         <label class="col-sm-3 control-label">Name *</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" placeholder="e.g. hello" v-model="fn.name" :disabled="edit" @keydown.enter.prevent="">
+          <input id="fnName" type="text" class="form-control" placeholder="e.g. hello" v-model="fn.name" :disabled="edit" @keydown.enter.prevent="">
         </div>
       </div>
       <input type="hidden" class="form-control" v-model="fn.app_id">
       <div class="form-group">
         <label class="col-sm-3 control-label">Image *</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" placeholder="e.g. fnproject/hello"  v-model="fn.image" @keydown.enter.prevent="">
+          <input id="fnImage" type="text" class="form-control" placeholder="e.g. fnproject/hello"  v-model="fn.image" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Memory, MB</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 128"  v-model.number="fn.memory" @keydown.enter.prevent="">
+          <input id="fnMemory" type="number" class="form-control" placeholder="e.g. 128"  v-model.number="fn.memory" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Timeout, sec</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 60"  v-model.number="fn.timeout" @keydown.enter.prevent="">
+          <input id="fnTimeout" type="number" class="form-control" placeholder="e.g. 60"  v-model.number="fn.timeout" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Idle Timeout, sec</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 60"  v-model.number="fn.idle_timeout" @keydown.enter.prevent="">
+          <input id="FnIdleTimeout" type="number" class="form-control" placeholder="e.g. 60"  v-model.number="fn.idle_timeout" @keydown.enter.prevent="">
         </div>
       </div>
 
@@ -39,7 +39,7 @@
     </form>
 
     <div slot="footer">
-      <button type="button" class="btn btn-primary" @click="ok" :disabled="submitting">{{okBtnName()}}</button>
+      <button id="submitFn" type="button" class="btn btn-primary" @click="ok" :disabled="submitting">{{okBtnName()}}</button>
     </div>
   </modal>
 </template>

--- a/client/pages/AppPage.vue
+++ b/client/pages/AppPage.vue
@@ -11,7 +11,7 @@
       {{app.name}}
 
       <div class="pull-right">
-        <button class="btn btn-default" @click="openAddFn()"><i class="fa fa-plus"></i> Add Function</button>
+        <button id="openCreateFn" class="btn btn-default" @click="openAddFn()"><i class="fa fa-plus"></i> Add Function</button>
       </div>
     </h1>
 
@@ -20,7 +20,7 @@
     <!-- <div class="table-responsive"> -->
     <div class="row">
       <div class="col-md-12 col-lg-10">
-        <table class="table table-striped">
+        <table id="fnTable" class="table table-striped">
           <thead v-bind:class="{ transparent: fns.length == 0 }">
             <th>Name</th>
             <th>Image</th>
@@ -30,27 +30,27 @@
             <th width="140">Actions</th>
           </thead>
           <tbody>
-            <tr v-for="fn in fns">
-              <td>{{fn.name}}</td>
-              <td>{{fn.image}}</td>
-              <td>{{fn.memory}} MB</td>
-              <td>{{fn.timeout}}</td>
-              <td>{{fn.idle_timeout}}</td>
+            <tr :name="fn.name" v-for="fn in fns">
+              <td name="name">{{fn.name}}</td>
+              <td name="image">{{fn.image}}</td>
+              <td name="memory">{{fn.memory}} MB</td>
+              <td name="timeout">{{fn.timeout}}</td>
+              <td name="idleTimeout">{{fn.idle_timeout}}</td>
               <td>
                 <div class="toolbar">
 
                   <div class="btn-group">
-                    <button class="btn btn-default btn-sm" @click.prevent="openRunFn(fn)" title="Run Function"><i class="fa fa-play"></i> Run Function</button>
-                    <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <button name="runFn" class="btn btn-default btn-sm" @click.prevent="openRunFn(fn)" title="Run Function"><i class="fa fa-play"></i> Run Function</button>
+                    <button name="openMoreOptions" type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                       <span class="caret"></span>
                       <span class="sr-only">Toggle Dropdown</span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right">
                       <li>
-                        <a href="#" @click.prevent="openEditFn(fn)" title="Edit Function">
+                        <a name="openEditFn" href="#" @click.prevent="openEditFn(fn)" title="Edit Function">
                           <i class="fa fa-gear"></i> Edit Function
                         </a>
-                        <a href="#" @click.prevent="deleteFn(fn)"
+                        <a name="deleteFn" href="#" @click.prevent="deleteFn(fn)"
                         class="text-danger" title="Delete Function">
                           <i class="fa fa-times"></i> Delete Function
                         </a>

--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -9,7 +9,7 @@
       Dashboard
    
       <div class="pull-right">
-        <button class="btn btn-default" @click="openAddApp">
+        <button id="openCreateApp" class="btn btn-default" @click="openAddApp">
           <i class="fa fa-plus"></i>&nbsp;
           Create App
         </button>
@@ -22,13 +22,13 @@
       <div class="col-md-12 col-lg-10">
         <!-- <div class="table-responsive"> -->
         <div>
-          <table class="table table-striped">
+          <table id="appsTable" class="table table-striped">
             <thead v-bind:class="{ transparent: !apps || apps.length == 0 }">
               <th>Name</th>
               <th width="120">Actions</th>
             </thead>
             <tbody>
-              <tr v-for="app in apps">
+              <tr :name="app.name" v-for="app in apps">
                 <td>
                   <router-link :to="'/app/' + encodeURIComponent(app.id)">{{app.name}}</router-link>
                 </td>
@@ -36,14 +36,14 @@
                   <div class="toolbar">
 
                     <div class="btn-group">
-                      <button class="btn btn-default btn-sm" @click.prevent="openEditApp(app)" title="Edit App"><i class="fa fa-gear"></i> Edit</button>
-                      <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      <button name="openEditApp" class="btn btn-default btn-sm" @click.prevent="openEditApp(app)" title="Edit App"><i class="fa fa-gear"></i> Edit</button>
+                      <button name="openMoreOptions" type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>
                       </button>
                       <ul class="dropdown-menu dropdown-menu-right">
                         <li>
-                          <a href="#" @click.prevent="deleteApp(app)" class="text-danger"  title="Delete App">
+                          <a name="deleteApp" href="#" @click.prevent="deleteApp(app)" class="text-danger"  title="Delete App">
                             <i class="fa fa-times"></i> Delete App
                           </a>
                         </li>

--- a/client/pages/IndexPage.vue
+++ b/client/pages/IndexPage.vue
@@ -30,7 +30,7 @@
             <tbody>
               <tr :name="app.name" v-for="app in apps">
                 <td>
-                  <router-link :to="'/app/' + encodeURIComponent(app.id)">{{app.name}}</router-link>
+                  <router-link :to="'/app/' + encodeURIComponent(app.id)" name="appLink">{{app.name}}</router-link>
                 </td>
                 <td>
                   <div class="toolbar">

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-vue": "^5.2.2",
     "mocha": "^6.1.4",
     "randomstring": "^1.1.5",
-    "selenium-webdriver": "^4.0.0-alpha.1"
+    "selenium-webdriver": "^4.0.0-alpha.1",
+    "yaml": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.37",
   "private": true,
   "scripts": {
-    "start": "node server"
+    "start": "node server",
+    "test-integration": "./node_modules/.bin/mocha test_integration/test_*.js"
   },
   "dependencies": {
     "babel-core": "^6.0.0",
@@ -46,7 +47,11 @@
     "webpack": "^1.14.0"
   },
   "devDependencies": {
+    "assert": "^2.0.0",
     "eslint": "^5.16.0",
-    "eslint-plugin-vue": "^5.2.2"
+    "eslint-plugin-vue": "^5.2.2",
+    "mocha": "^6.1.4",
+    "randomstring": "^1.1.5",
+    "selenium-webdriver": "^4.0.0-alpha.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "assert": "^2.0.0",
     "eslint": "^5.16.0",
+    "eslint-plugin-mocha": "^5.3.0",
     "eslint-plugin-vue": "^5.2.2",
     "mocha": "^6.1.4",
     "randomstring": "^1.1.5",

--- a/test_integration/etc/config.yaml
+++ b/test_integration/etc/config.yaml
@@ -1,0 +1,8 @@
+# This config is used for the Fn UI's Selenium tests.
+
+fn_ui:
+  # The URL to the Fn UI that you want to test.
+  fn_url: 'http://localhost:4000/'
+
+  # Whether to run the tests in a headless browser
+  headless: true

--- a/test_integration/lib/app_details.js
+++ b/test_integration/lib/app_details.js
@@ -1,0 +1,32 @@
+module.exports = class AppDetails {
+  constructor(name, syslogUrl=null) {
+    this.attributes = {
+      name: new AppAttribute(name, 'appName', false),
+      image: new AppAttribute(syslogUrl, 'appSyslogUrl'),
+    };
+  }
+
+  get name() {
+    return this.attributes.name.value;
+  }
+
+  getAttributes() {
+    return Object.values(this.attributes).filter( (attribute) => {
+      return attribute.value !== null;
+    });
+  }
+
+  getEditableAttributes() {
+    return this.getAttributes().filter( (attribute) => {
+      return attribute.isEditable;
+    });
+  }
+};
+
+class AppAttribute {
+  constructor(value, elementId, isEditable=true) {
+    this.value = value;
+    this.elementId = elementId;
+    this.isEditable = isEditable;
+  }
+}

--- a/test_integration/lib/app_details.js
+++ b/test_integration/lib/app_details.js
@@ -1,11 +1,16 @@
 const FormAttribute = require('./form_attribute.js');
 const FormDetails = require('./form_details.js');
+const HomepageSelector = require('./homepage_selector.js');
 
 module.exports = class AppDetails extends FormDetails {
   constructor(name, syslogUrl=null) {
     super({
-      name: new FormAttribute(name, 'appName', false),
-      image: new FormAttribute(syslogUrl, 'appSyslogUrl'),
+      name: new FormAttribute(
+        name, HomepageSelector.appNameInput(), false
+      ),
+      syslog_url: new FormAttribute(
+        syslogUrl, HomepageSelector.appSyslogUrlInput()
+      ),
     });
   }
 };

--- a/test_integration/lib/app_details.js
+++ b/test_integration/lib/app_details.js
@@ -2,7 +2,18 @@ const FormAttribute = require('./form_attribute.js');
 const FormDetails = require('./form_details.js');
 const HomepageSelector = require('./homepage_selector.js');
 
+/*
+ * This class is used to edit/add Fn Apps using the create/edit App form
+ * on the Fn UI
+ *
+ * It contains a mapping of where to find the form field on the page and what
+ * the value should be set to
+ */
 module.exports = class AppDetails extends FormDetails {
+  /*
+   * @param name {String} - the name of the App
+   * @param syslogUrl {String} - the syslog URL for the app
+   */
   constructor(name, syslogUrl=null) {
     super({
       name: new FormAttribute(

--- a/test_integration/lib/app_details.js
+++ b/test_integration/lib/app_details.js
@@ -1,32 +1,11 @@
-module.exports = class AppDetails {
+const FormAttribute = require('./form_attribute.js');
+const FormDetails = require('./form_details.js');
+
+module.exports = class AppDetails extends FormDetails {
   constructor(name, syslogUrl=null) {
-    this.attributes = {
-      name: new AppAttribute(name, 'appName', false),
-      image: new AppAttribute(syslogUrl, 'appSyslogUrl'),
-    };
-  }
-
-  get name() {
-    return this.attributes.name.value;
-  }
-
-  getAttributes() {
-    return Object.values(this.attributes).filter( (attribute) => {
-      return attribute.value !== null;
-    });
-  }
-
-  getEditableAttributes() {
-    return this.getAttributes().filter( (attribute) => {
-      return attribute.isEditable;
+    super({
+      name: new FormAttribute(name, 'appName', false),
+      image: new FormAttribute(syslogUrl, 'appSyslogUrl'),
     });
   }
 };
-
-class AppAttribute {
-  constructor(value, elementId, isEditable=true) {
-    this.value = value;
-    this.elementId = elementId;
-    this.isEditable = isEditable;
-  }
-}

--- a/test_integration/lib/app_page.js
+++ b/test_integration/lib/app_page.js
@@ -3,12 +3,29 @@ const {until} = require('selenium-webdriver');
 const AppPageSelector = require('./app_page_selector.js');
 const FnPage = require('./fn_page.js');
 
+/*
+ * This class provides an interface to the App Details page on the Fn UI
+ *
+ * For example, it can be used to create a new function for an app, edit
+ * details for an existing app, etc
+ */
 module.exports = class AppPage extends FnPage {
 
+  // Get the css selector for the provided function row in the functions table
   _fnTableRowSelector(fnName) {
     return `#fnTable tr[name="${fnName}"]`;
   }
 
+  /*
+   * Get the value of the provided HTML element's field
+   *
+   * @param fnName {String} - the name of the Fn Function that the field
+   *        belongs to
+   * @param elementDetails {ElementDetails} - an instance of ElementDetails
+   *        containing information on how to locate this HTML element
+   *
+   * @return - the value of the HTML element
+   */
   async _getFnAttribute(fnName, elementDetails) {
     await this.openEditFn(fnName);
 
@@ -17,26 +34,35 @@ module.exports = class AppPage extends FnPage {
     return await inputField.getAttribute('value');
   }
 
+  // Checks if the App page loaded correctly
   async loadedCorrectly() {
     let fnTable = await this.getFnTable();
     let fnTableText = await fnTable.getText();
     return fnTableText.includes('No Functions');
   }
 
+  // Opens the CreateFn Modal
   async openCreateFn() {
     let openCreateFnBtn =
       await this.findByElementDetails(AppPageSelector.openCreateFnBtn());
     await openCreateFnBtn.click();
   }
 
+  // Gets the table containing information about the App's functions
   async getFnTable() {
     return await this.findByElementDetails(AppPageSelector.fnTable());
   }
 
+  // Gets the row containing information about the provided Function's details
   async getFnTableRow(fnName) {
     return await this.findByElementDetails(AppPageSelector.fnTableRow(fnName));
   }
 
+  /*
+   * Creates a new Function using the app details page
+   *
+   * @param fnDetails {FnDetails} - details of the Function you want to create
+   */
   async createFn(fnDetails) {
     await this.openCreateFn();
     await this._fillFormDetails(fnDetails.getAttributes());
@@ -44,6 +70,7 @@ module.exports = class AppPage extends FnPage {
     await this.getFnTableRow(fnDetails.name);
   }
 
+  // Opens the EditFn modal for the specified function
   async openEditFn(fnName) {
     await this.openFnOptions(fnName);
     let openEditFnBtn =
@@ -51,24 +78,33 @@ module.exports = class AppPage extends FnPage {
     await openEditFnBtn.click();
   }
 
+  /*
+   * Edits an existing Function using the fnDetails provided
+   *
+   * @param fnDetails {FnDetails} - the new Function details you want to use
+   */
   async editFn(fnDetails) {
     await this.openEditFn(fnDetails.name);
     await this._fillFormDetails(fnDetails.getEditableAttributes());
     await this.submitFn();
   }
 
+  // Submits the new/edit Function form
   async submitFn() {
     let submitFnBtn =
       await this.findByElementDetails(AppPageSelector.submitFnBtn());
     await submitFnBtn.click();
   }
 
+  // Opens the dropdown containing additional options that can be performed
+  // on the Function
   async openFnOptions(fnName) {
     let moreOptionsBtn =
       await this.findByElementDetails(AppPageSelector.openMoreOptionsBtn(fnName));
     await moreOptionsBtn.click();
   }
 
+  // Deletes the specified function
   async deleteFn(fnName) {
     await this.openFnOptions(fnName);
 
@@ -81,18 +117,22 @@ module.exports = class AppPage extends FnPage {
     await deleteConfirmation.accept();
   }
 
+  // Gets the specified function's image details from the interface
   async getFnImage(fnName) {
     return await this._getFnAttribute(fnName, AppPageSelector.fnImageInput());
   }
 
+  // Gets the specified function's memory limits from the interface
   async getFnMemory(fnName) {
     return await this._getFnAttribute(fnName, AppPageSelector.fnMemoryInput());
   }
 
+  // Gets the specified function's timeout from the interface
   async getFnTimeout(fnName) {
     return await this._getFnAttribute(fnName, AppPageSelector.fnTimeoutInput());
   }
 
+  // Gets the specified function's idle timeout from the interface
   async getFnIdleTimeout(fnName) {
     return await this._getFnAttribute(
       fnName, AppPageSelector.fnIdleTimeoutInput()

--- a/test_integration/lib/app_page.js
+++ b/test_integration/lib/app_page.js
@@ -9,6 +9,14 @@ module.exports = class AppPage extends FnPage {
     return `#fnTable tr[name="${fnName}"]`;
   }
 
+  async _getFnAttribute(fnName, elementDetails) {
+    await this.openEditFn(fnName);
+
+    let inputField =
+      await this.findByElementDetails(elementDetails);
+    return await inputField.getAttribute('value');
+  }
+
   async loadedCorrectly() {
     let fnTable = await this.getFnTable();
     let fnTableText = await fnTable.getText();
@@ -55,15 +63,6 @@ module.exports = class AppPage extends FnPage {
     await submitFnBtn.click();
   }
 
-  //TODO think of a way to generalise this for each app parameter
-  async getFnImage(fnName) {
-    await this.openEditFn(fnName);
-
-    let fnImageInput =
-      await this.findByElementDetails(AppPageSelector.fnImageInput());
-    return await fnImageInput.getAttribute('value');
-  }
-
   async openFnOptions(fnName) {
     let moreOptionsBtn =
       await this.findByElementDetails(AppPageSelector.openMoreOptionsBtn(fnName));
@@ -80,5 +79,23 @@ module.exports = class AppPage extends FnPage {
     let deleteConfirmation = await this.driver.wait(
       until.alertIsPresent(), 10000, 'Waiting for alert');
     await deleteConfirmation.accept();
+  }
+
+  async getFnImage(fnName) {
+    return await this._getFnAttribute(fnName, AppPageSelector.fnImageInput());
+  }
+
+  async getFnMemory(fnName) {
+    return await this._getFnAttribute(fnName, AppPageSelector.fnMemoryInput());
+  }
+
+  async getFnTimeout(fnName) {
+    return await this._getFnAttribute(fnName, AppPageSelector.fnTimeoutInput());
+  }
+
+  async getFnIdleTimeout(fnName) {
+    return await this._getFnAttribute(
+      fnName, AppPageSelector.fnIdleTimeoutInput()
+    );
   }
 };

--- a/test_integration/lib/app_page.js
+++ b/test_integration/lib/app_page.js
@@ -1,5 +1,6 @@
 const {until} = require('selenium-webdriver');
 
+const AppPageSelector = require('./app_page_selector.js');
 const FnPage = require('./fn_page.js');
 
 module.exports = class AppPage extends FnPage {
@@ -15,16 +16,17 @@ module.exports = class AppPage extends FnPage {
   }
 
   async openCreateFn() {
-    let openCreateFnBtn = await this.findById('openCreateFn');
+    let openCreateFnBtn =
+      await this.findByElementDetails(AppPageSelector.openCreateFnBtn());
     await openCreateFnBtn.click();
   }
 
   async getFnTable() {
-    return await this.findById('fnTable');
+    return await this.findByElementDetails(AppPageSelector.fnTable());
   }
 
   async getFnTableRow(fnName) {
-    return await this.findByCss(this._fnTableRowSelector(fnName));
+    return await this.findByElementDetails(AppPageSelector.fnTableRow(fnName));
   }
 
   async createFn(fnDetails) {
@@ -36,7 +38,8 @@ module.exports = class AppPage extends FnPage {
 
   async openEditFn(fnName) {
     await this.openFnOptions(fnName);
-    let openEditFnBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="openEditFn"]');
+    let openEditFnBtn =
+      await this.findByElementDetails(AppPageSelector.openEditFnBtn(fnName));
     await openEditFnBtn.click();
   }
 
@@ -47,7 +50,8 @@ module.exports = class AppPage extends FnPage {
   }
 
   async submitFn() {
-    let submitFnBtn = await this.findById('submitFn');
+    let submitFnBtn =
+      await this.findByElementDetails(AppPageSelector.submitFnBtn());
     await submitFnBtn.click();
   }
 
@@ -55,22 +59,26 @@ module.exports = class AppPage extends FnPage {
   async getFnImage(fnName) {
     await this.openEditFn(fnName);
 
-    let fnImageInput = await this.findById('fnImage');
+    let fnImageInput =
+      await this.findByElementDetails(AppPageSelector.fnImageInput());
     return await fnImageInput.getAttribute('value');
   }
 
   async openFnOptions(fnName) {
-    let moreOptionsBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="openMoreOptions"]');
+    let moreOptionsBtn =
+      await this.findByElementDetails(AppPageSelector.openMoreOptionsBtn(fnName));
     await moreOptionsBtn.click();
   }
 
   async deleteFn(fnName) {
     await this.openFnOptions(fnName);
 
-    let deleteBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="deleteFn"]');
+    let deleteBtn =
+      await this.findByElementDetails(AppPageSelector.deleteFnBtn(fnName));
     await deleteBtn.click();
 
-    let deleteConfirmation = await this.driver.wait(until.alertIsPresent(), 10000, 'Waiting for alert');
+    let deleteConfirmation = await this.driver.wait(
+      until.alertIsPresent(), 10000, 'Waiting for alert');
     await deleteConfirmation.accept();
   }
 };

--- a/test_integration/lib/app_page.js
+++ b/test_integration/lib/app_page.js
@@ -1,0 +1,76 @@
+const {until} = require('selenium-webdriver');
+
+const FnPage = require('./fn_page.js');
+
+module.exports = class AppPage extends FnPage {
+
+  _fnTableRowSelector(fnName) {
+    return `#fnTable tr[name="${fnName}"]`;
+  }
+
+  async loadedCorrectly() {
+    let fnTable = await this.getFnTable();
+    let fnTableText = await fnTable.getText();
+    return fnTableText.includes('No Functions');
+  }
+
+  async openCreateFn() {
+    let openCreateFnBtn = await this.findById('openCreateFn');
+    await openCreateFnBtn.click();
+  }
+
+  async getFnTable() {
+    return await this.findById('fnTable');
+  }
+
+  async getFnTableRow(fnName) {
+    return await this.findByCss(this._fnTableRowSelector(fnName));
+  }
+
+  async createFn(fnDetails) {
+    await this.openCreateFn();
+    await this._fillFormDetails(fnDetails.getAttributes());
+    await this.submitFn();
+    await this.getFnTableRow(fnDetails.name);
+  }
+
+  async openEditFn(fnName) {
+    await this.openFnOptions(fnName);
+    let openEditFnBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="openEditFn"]');
+    await openEditFnBtn.click();
+  }
+
+  async editFn(fnDetails) {
+    await this.openEditFn(fnDetails.name);
+    await this._fillFormDetails(fnDetails.getEditableAttributes());
+    await this.submitFn();
+  }
+
+  async submitFn() {
+    let submitFnBtn = await this.findById('submitFn');
+    await submitFnBtn.click();
+  }
+
+  //TODO think of a way to generalise this for each app parameter
+  async getFnImage(fnName) {
+    await this.openEditFn(fnName);
+
+    let fnImageInput = await this.findById('fnImage');
+    return await fnImageInput.getAttribute('value');
+  }
+
+  async openFnOptions(fnName) {
+    let moreOptionsBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="openMoreOptions"]');
+    await moreOptionsBtn.click();
+  }
+
+  async deleteFn(fnName) {
+    await this.openFnOptions(fnName);
+
+    let deleteBtn = await this.findByCss(this._fnTableRowSelector(fnName) + ' [name="deleteFn"]');
+    await deleteBtn.click();
+
+    let deleteConfirmation = await this.driver.wait(until.alertIsPresent(), 10000, 'Waiting for alert');
+    await deleteConfirmation.accept();
+  }
+};

--- a/test_integration/lib/app_page_selector.js
+++ b/test_integration/lib/app_page_selector.js
@@ -1,0 +1,63 @@
+const ElementDetails = require('./element_details.js');
+
+function _fnTableRowSelector(fnName) {
+  return `#fnTable tr[name="${fnName}"]`;
+}
+
+function _fnTableRowElement(fnName, elementSelector) {
+  return new ElementDetails(
+   _fnTableRowSelector(fnName) + ' ' + elementSelector,
+    ElementDetails.TYPE.CSS
+  );
+}
+
+exports.fnTableRow = function(fnName) {
+  return new ElementDetails(
+    _fnTableRowSelector(fnName),
+    ElementDetails.TYPE.CSS
+  );
+};
+
+exports.openCreateFnBtn = function() {
+  return new ElementDetails('openCreateFn', ElementDetails.TYPE.ID);
+};
+
+exports.fnTable = function() {
+  return new ElementDetails('fnTable', ElementDetails.TYPE.ID);
+};
+
+exports.submitFnBtn = function() {
+  return new ElementDetails('submitFn', ElementDetails.TYPE.ID);
+};
+
+exports.fnNameInput = function() {
+  return new ElementDetails('fnName', ElementDetails.TYPE.ID);
+};
+
+exports.fnImageInput = function() {
+  return new ElementDetails('fnImage', ElementDetails.TYPE.ID);
+};
+
+exports.fnMemoryInput = function() {
+  return new ElementDetails('fnMemory', ElementDetails.TYPE.ID);
+};
+
+exports.fnTimeoutInput = function() {
+  return new ElementDetails('fnTimeout', ElementDetails.TYPE.ID);
+};
+
+exports.fnIdleTimeoutInput = function() {
+  return new ElementDetails('fnIdleTimeout', ElementDetails.TYPE.ID);
+};
+
+exports.openEditFnBtn = function(fnName) {
+  return _fnTableRowElement(fnName, '[name="openEditFn"]');
+};
+
+exports.openMoreOptionsBtn = function(fnName) {
+  return _fnTableRowElement(fnName, '[name="openMoreOptions"]');
+};
+
+exports.deleteFnBtn = function(fnName) {
+  return _fnTableRowElement(fnName, '[name="deleteFn"]');
+};

--- a/test_integration/lib/app_page_selector.js
+++ b/test_integration/lib/app_page_selector.js
@@ -1,9 +1,18 @@
 const ElementDetails = require('./element_details.js');
 
+/*
+ * This module contains information about how to find elements on the Fn UI's
+ * App Details page
+ */
+
+// Return the CSS selector for the table row which contains information about
+// the specified Function
 function _fnTableRowSelector(fnName) {
   return `#fnTable tr[name="${fnName}"]`;
 }
 
+// Helper function for HTML elements which are located in the Functions table.
+// It appends the element's selector to the end of the Fn Table row selector
 function _fnTableRowElement(fnName, elementSelector) {
   return new ElementDetails(
    _fnTableRowSelector(fnName) + ' ' + elementSelector,
@@ -11,6 +20,7 @@ function _fnTableRowElement(fnName, elementSelector) {
   );
 }
 
+// Return information on how to find the Function's row in the Fn Table
 exports.fnTableRow = function(fnName) {
   return new ElementDetails(
     _fnTableRowSelector(fnName),
@@ -18,46 +28,57 @@ exports.fnTableRow = function(fnName) {
   );
 };
 
+// Return information on how to find the openCreateFn button
 exports.openCreateFnBtn = function() {
   return new ElementDetails('openCreateFn', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the Functions table
 exports.fnTable = function() {
   return new ElementDetails('fnTable', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the create/edit Function submit button
 exports.submitFnBtn = function() {
   return new ElementDetails('submitFn', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the fn name input field
 exports.fnNameInput = function() {
   return new ElementDetails('fnName', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the fn image input field
 exports.fnImageInput = function() {
   return new ElementDetails('fnImage', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the fn memory input field
 exports.fnMemoryInput = function() {
   return new ElementDetails('fnMemory', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the fn timeout input field
 exports.fnTimeoutInput = function() {
   return new ElementDetails('fnTimeout', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the fn idle timeout input field
 exports.fnIdleTimeoutInput = function() {
   return new ElementDetails('fnIdleTimeout', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the edit Fn button
 exports.openEditFnBtn = function(fnName) {
   return _fnTableRowElement(fnName, '[name="openEditFn"]');
 };
 
+// Return information on how to find the Fn more options button
 exports.openMoreOptionsBtn = function(fnName) {
   return _fnTableRowElement(fnName, '[name="openMoreOptions"]');
 };
 
+// Return information on how to find the delete Fn button
 exports.deleteFnBtn = function(fnName) {
   return _fnTableRowElement(fnName, '[name="deleteFn"]');
 };

--- a/test_integration/lib/config.js
+++ b/test_integration/lib/config.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const yaml = require('yaml');
+
+module.exports = class Config {
+  constructor(configLocation='test_integration/etc/config.yaml') {
+    this.defaults = {
+      fn_url: 'http://localhost:4000/',
+      headless: true,
+    };
+
+    let configFile;
+    try {
+      configFile = fs.readFileSync(configLocation, 'utf8');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`Unable to read config file: ${configLocation}. ${err}`);
+      return;
+    }
+
+    this.config = yaml.parse(configFile);
+  }
+
+  get(key, defaultOverride=null) {
+    if(this.config !== undefined &&
+      this.config.fn_ui !== undefined &&
+      this.config.fn_ui[key] !== null
+    ) {
+      return this.config.fn_ui[key];
+    }
+
+    if(defaultOverride !== null) {
+      return defaultOverride;
+    }
+
+    return this.defaults[key];
+  }
+};

--- a/test_integration/lib/config.js
+++ b/test_integration/lib/config.js
@@ -1,8 +1,13 @@
 const fs = require('fs');
 const yaml = require('yaml');
 
+/*
+ * This class is used to access values from the integration test config
+ */
 module.exports = class Config {
   constructor(configLocation='test_integration/etc/config.yaml') {
+
+    // Stores default values to use if they aren't specified in the config
     this.defaults = {
       fn_url: 'http://localhost:4000/',
       headless: true,
@@ -20,7 +25,22 @@ module.exports = class Config {
     this.config = yaml.parse(configFile);
   }
 
+  /*
+   * Get the config value
+   *
+   * It will first try to use the value specified in the config file. If this
+   * doesn't exist, it will then use the value provided in defaultOverride,
+   * if this is null then it will use the default value for the config key
+   *
+   * @param key {String} - the key for the config value you wish to get
+   * @param defaultOverride - the value to use if the config value does not
+   *        exist. If set to null, it will use the default value as specified
+   *        by the class.
+   *
+   * @return - the value of config
+   */
   get(key, defaultOverride=null) {
+    // If the value's specified in the config, use this
     if(this.config !== undefined &&
       this.config.fn_ui !== undefined &&
       this.config.fn_ui[key] !== null
@@ -28,10 +48,12 @@ module.exports = class Config {
       return this.config.fn_ui[key];
     }
 
+    // Otherwise use the defaultOverride value if it's been specified
     if(defaultOverride !== null) {
       return defaultOverride;
     }
 
+    // Otherwise use the default value according to this class
     return this.defaults[key];
   }
 };

--- a/test_integration/lib/element_details.js
+++ b/test_integration/lib/element_details.js
@@ -1,9 +1,23 @@
+/*
+ * This class contains information about how to locate an HTML element
+ */
 module.exports = class ElementDetails {
+  /*
+   * @param selector {String} - how to locate the element on the page e.g.
+   *        the css selector or the element's HTML id
+   * @param type {ElementDetails.TYPE} - information about what the selector
+   *        string contains. E.g. CSS for a CSS selector
+   */
   constructor(selector, type) {
     this.selector = selector;
     this.type = type;
   }
 
+  /*
+   * Valid types are:
+   * CSS - to denote this.selector is a CSS selector
+   * ID - to deonote this.selector is an HTML id
+   */
   static get TYPE() {
     return Object.freeze({
       CSS: 1,

--- a/test_integration/lib/element_details.js
+++ b/test_integration/lib/element_details.js
@@ -1,0 +1,13 @@
+module.exports = class ElementDetails {
+  constructor(selector, type) {
+    this.selector = selector;
+    this.type = type;
+  }
+
+  static get TYPE() {
+    return Object.freeze({
+      CSS: 1,
+      ID: 2,
+    });
+  }
+};

--- a/test_integration/lib/exceptions.js
+++ b/test_integration/lib/exceptions.js
@@ -1,0 +1,5 @@
+class UnimplementedError extends Error {}
+
+module.exports = {
+  UnimplementedError: UnimplementedError,
+};

--- a/test_integration/lib/exceptions.js
+++ b/test_integration/lib/exceptions.js
@@ -1,3 +1,7 @@
+/*
+ * A module containing custom exceptions used by the integration tests
+ */
+
 class UnimplementedError extends Error {}
 
 module.exports = {

--- a/test_integration/lib/fn_details.js
+++ b/test_integration/lib/fn_details.js
@@ -1,35 +1,14 @@
-module.exports = class FnDetails {
+const FormAttribute = require('./form_attribute.js');
+const FormDetails = require('./form_details.js');
+
+module.exports = class FnDetails extends FormDetails {
   constructor(name, image, memory=null, timeout=null, idle_timeout=null) {
-    this.attributes = {
-      name: new FunctionAttribute(name, 'fnName', false),
-      image: new FunctionAttribute(image, 'fnImage'),
-      memory: new FunctionAttribute(memory, 'fnMemory'),
-      timeout: new FunctionAttribute(timeout, 'fnTimeout'),
-      idle_timeout: new FunctionAttribute(idle_timeout, 'fnIdleTimeout'),
-    };
-  }
-
-  get name() {
-    return this.attributes.name.value;
-  }
-
-  getAttributes() {
-    return Object.values(this.attributes).filter( (attribute) => {
-      return attribute.value !== null;
-    });
-  }
-
-  getEditableAttributes() {
-    return this.getAttributes().filter( (attribute) => {
-      return attribute.isEditable;
+    super({
+      name: new FormAttribute(name, 'fnName', false),
+      image: new FormAttribute(image, 'fnImage'),
+      memory: new FormAttribute(memory, 'fnMemory'),
+      timeout: new FormAttribute(timeout, 'fnTimeout'),
+      idle_timeout: new FormAttribute(idle_timeout, 'fnIdleTimeout'),
     });
   }
 };
-
-class FunctionAttribute {
-  constructor(value, elementId, isEditable=true) {
-    this.value = value;
-    this.elementId = elementId;
-    this.isEditable = isEditable;
-  }
-}

--- a/test_integration/lib/fn_details.js
+++ b/test_integration/lib/fn_details.js
@@ -1,14 +1,25 @@
+const AppPageSelector = require('./app_page_selector.js');
 const FormAttribute = require('./form_attribute.js');
 const FormDetails = require('./form_details.js');
 
 module.exports = class FnDetails extends FormDetails {
   constructor(name, image, memory=null, timeout=null, idle_timeout=null) {
     super({
-      name: new FormAttribute(name, 'fnName', false),
-      image: new FormAttribute(image, 'fnImage'),
-      memory: new FormAttribute(memory, 'fnMemory'),
-      timeout: new FormAttribute(timeout, 'fnTimeout'),
-      idle_timeout: new FormAttribute(idle_timeout, 'fnIdleTimeout'),
+      name: new FormAttribute(
+        name, AppPageSelector.fnNameInput(), false
+      ),
+      image: new FormAttribute(
+        image, AppPageSelector.fnImageInput()
+      ),
+      memory: new FormAttribute(
+        memory, AppPageSelector.fnMemoryInput()
+      ),
+      timeout: new FormAttribute(
+        timeout, AppPageSelector.fnTimeoutInput()
+      ),
+      idle_timeout: new FormAttribute(
+        idle_timeout, AppPageSelector.fnIdleTimeoutInput()
+      ),
     });
   }
 };

--- a/test_integration/lib/fn_details.js
+++ b/test_integration/lib/fn_details.js
@@ -1,0 +1,35 @@
+module.exports = class FnDetails {
+  constructor(name, image, memory=null, timeout=null, idle_timeout=null) {
+    this.attributes = {
+      name: new FunctionAttribute(name, 'fnName', false),
+      image: new FunctionAttribute(image, 'fnImage'),
+      memory: new FunctionAttribute(memory, 'fnMemory'),
+      timeout: new FunctionAttribute(timeout, 'fnTimeout'),
+      idle_timeout: new FunctionAttribute(idle_timeout, 'fnIdleTimeout'),
+    };
+  }
+
+  get name() {
+    return this.attributes.name.value;
+  }
+
+  getAttributes() {
+    return Object.values(this.attributes).filter( (attribute) => {
+      return attribute.value !== null;
+    });
+  }
+
+  getEditableAttributes() {
+    return this.getAttributes().filter( (attribute) => {
+      return attribute.isEditable;
+    });
+  }
+};
+
+class FunctionAttribute {
+  constructor(value, elementId, isEditable=true) {
+    this.value = value;
+    this.elementId = elementId;
+    this.isEditable = isEditable;
+  }
+}

--- a/test_integration/lib/fn_details.js
+++ b/test_integration/lib/fn_details.js
@@ -2,7 +2,21 @@ const AppPageSelector = require('./app_page_selector.js');
 const FormAttribute = require('./form_attribute.js');
 const FormDetails = require('./form_details.js');
 
+/*
+ * This class is used to edit/add Fn Functions using the create/edit Function
+ * form on the Fn UI
+ *
+ * It contains a mapping of where to find the form field on the page and what
+ * the value should be set to
+ */
 module.exports = class FnDetails extends FormDetails {
+  /*
+   * @param name {String} - the name of the Function
+   * @param image {String} - the image the Function uses
+   * @param memory {Integer} - the memory limit of the Function
+   * @param timeout {Integet} - the timeout for the Function
+   * @param idle_timeout {Integer} - the idle timeout for the Function
+   */
   constructor(name, image, memory=null, timeout=null, idle_timeout=null) {
     super({
       name: new FormAttribute(

--- a/test_integration/lib/fn_page.js
+++ b/test_integration/lib/fn_page.js
@@ -1,0 +1,23 @@
+const Page = require('./page.js');
+
+module.exports = class FnPage extends Page {
+  async getError() {
+    let flashMessageAlert = await this.findById('flash-messages');
+    return await flashMessageAlert.getText();
+  }
+
+  async _fillFormDetails(formDetails) {
+    let promiseArray = [];
+    for (let i = 0; i < formDetails.length; i++) {
+      let fillField = this.findById(formDetails[i].elementId)
+        .then(async function(field) {
+          await field.clear();
+          field.sendKeys(formDetails[i].value);
+        }
+      );
+
+      promiseArray.push(fillField);
+    }
+    await Promise.all(promiseArray);
+  }
+};

--- a/test_integration/lib/fn_page.js
+++ b/test_integration/lib/fn_page.js
@@ -1,3 +1,5 @@
+const ElementDetails = require('./element_details.js');
+const Exceptions = require('./exceptions.js');
 const Page = require('./page.js');
 
 module.exports = class FnPage extends Page {
@@ -19,5 +21,20 @@ module.exports = class FnPage extends Page {
       promiseArray.push(fillField);
     }
     await Promise.all(promiseArray);
+  }
+
+  async findByElementDetails(elementDetails) {
+    if (elementDetails.type === ElementDetails.TYPE.ID) {
+      return await this.findById(elementDetails.selector);
+    }
+
+    if (elementDetails.type === ElementDetails.TYPE.CSS) {
+      return await this.findByCss(elementDetails.selector);
+    }
+
+    throw new Exceptions.UnimplementedError(
+      `Unable to find element: '${elementDetails.selector}'. ` +
+      `Unimplemented element type: ${elementDetails.type}`
+    );
   }
 };

--- a/test_integration/lib/fn_page.js
+++ b/test_integration/lib/fn_page.js
@@ -2,12 +2,23 @@ const ElementDetails = require('./element_details.js');
 const Exceptions = require('./exceptions.js');
 const Page = require('./page.js');
 
+/*
+ * This class provides functionality for interacting with a page on the Fn UI
+ */
 module.exports = class FnPage extends Page {
+  // Gets the value of any error messages that have appeared on the Fn UI
   async getError() {
     let flashMessageAlert = await this.findById('flash-messages');
     return await flashMessageAlert.getText();
   }
 
+  /*
+   * Fills in an Fn form using the provided formDetails
+   *
+   * @param {FormDetails} formDetails - an instance of FormDetails containing
+   *        information on where to find the form elements and the values that
+   *        should be filled into the form
+   */
   async _fillFormDetails(formDetails) {
     let promiseArray = [];
     for (let i = 0; i < formDetails.length; i++) {
@@ -23,6 +34,14 @@ module.exports = class FnPage extends Page {
     await Promise.all(promiseArray);
   }
 
+  /*
+   * Find an element on the page using the provided elementDetails
+   *
+   * @param {ElementDetails} elementDetails - an instance of ElementDetails
+   *        containing information on how to find the HTML element.
+   *
+   * @return {selenium-webdriver.By} containing the HTML element location
+   */
   async findByElementDetails(elementDetails) {
     if (elementDetails.type === ElementDetails.TYPE.ID) {
       return await this.findById(elementDetails.selector);

--- a/test_integration/lib/form_attribute.js
+++ b/test_integration/lib/form_attribute.js
@@ -1,7 +1,18 @@
+const ElementDetails = require('./element_details.js');
+const Exceptions = require('./exceptions.js');
+
 module.exports = class FormAttribute {
-  constructor(value, elementId, isEditable=true) {
+  constructor(value, elementDetails, isEditable=true) {
     this.value = value;
-    this.elementId = elementId;
     this.isEditable = isEditable;
+
+    if (elementDetails.type !== ElementDetails.TYPE.ID) {
+      throw new Exceptions.UnimplementedError(
+        `Unimplemented element type: ${elementDetails.type} for ` +
+        `${elementDetails.selector}. FormAttribute only supports element IDs`
+      );
+    }
+
+    this.elementId = elementDetails.selector;
   }
 };

--- a/test_integration/lib/form_attribute.js
+++ b/test_integration/lib/form_attribute.js
@@ -1,7 +1,20 @@
 const ElementDetails = require('./element_details.js');
 const Exceptions = require('./exceptions.js');
 
+/*
+ * A class that encapsulates information about the UIs form fields such as
+ * if it's allowed to be edited and how to locate the form field on the page
+ * and the value we want it to contain
+ */
 module.exports = class FormAttribute {
+  /*
+   * @param {String} value - the value of the form field e.g. fnproject/hello
+   *        for the fn image's name
+   * @param {ElementDetails} elementDetails - an instance of ElementDetails
+   *        information about the element such as its location on the page
+   * @param {bool} isEditable - whether it's possible to update the field once
+   *        it's been created
+   */
   constructor(value, elementDetails, isEditable=true) {
     this.value = value;
     this.isEditable = isEditable;

--- a/test_integration/lib/form_attribute.js
+++ b/test_integration/lib/form_attribute.js
@@ -1,0 +1,7 @@
+module.exports = class FormAttribute {
+  constructor(value, elementId, isEditable=true) {
+    this.value = value;
+    this.elementId = elementId;
+    this.isEditable = isEditable;
+  }
+};

--- a/test_integration/lib/form_details.js
+++ b/test_integration/lib/form_details.js
@@ -1,0 +1,21 @@
+module.exports = class FormDetails {
+  constructor(attributes) {
+    this.attributes = attributes;
+  }
+
+  get name() {
+    return this.attributes.name.value;
+  }
+
+  getAttributes() {
+    return Object.values(this.attributes).filter( (attribute) => {
+      return attribute.value !== null;
+    });
+  }
+
+  getEditableAttributes() {
+    return this.getAttributes().filter( (attribute) => {
+      return attribute.isEditable;
+    });
+  }
+};

--- a/test_integration/lib/form_details.js
+++ b/test_integration/lib/form_details.js
@@ -1,18 +1,42 @@
+/*
+ * This class is used to store information about Fn forms that are on the Fn UI
+ */
 module.exports = class FormDetails {
+  /*
+   * @param attributes {Object} - a collection of FormAttributes which detail
+   *        information about the form's fields
+   */
   constructor(attributes) {
     this.attributes = attributes;
   }
 
+  /*
+   * Return the value of the name attribute
+   */
   get name() {
     return this.attributes.name.value;
   }
 
+  /*
+   * Get a list of all the valid FormAttributes for the Fn Form
+   *
+   * @return {Array} - an array of FormAttributes for the form
+   */
   getAttributes() {
     return Object.values(this.attributes).filter( (attribute) => {
       return attribute.value !== null;
     });
   }
 
+  /*
+   * Get a list of FormAttributes which can be edited
+   *
+   * This is used so that the Selenium tests don't try to edit fields that
+   * cannot be edited
+   *
+   * @return {Array} - an array of FormAttributes of form fields which can be
+   *         edited
+   */
   getEditableAttributes() {
     return this.getAttributes().filter( (attribute) => {
       return attribute.isEditable;

--- a/test_integration/lib/homepage.js
+++ b/test_integration/lib/homepage.js
@@ -1,0 +1,94 @@
+const {until} = require('selenium-webdriver');
+
+const Page = require('./page.js');
+
+module.exports = class HomePage extends Page {
+
+  _appTableRowSelector(appName) {
+    return `#appsTable tr[name="${appName}"]`;
+  }
+
+  async _fillAppAttributes(appAttributes) {
+    let promiseArray = [];
+    for (let i = 0; i < appAttributes.length; i++) {
+      let fillField = this.findById(appAttributes[i].elementId)
+        .then(async function(field) {
+          await field.clear();
+          field.sendKeys(appAttributes[i].value);
+        }
+      );
+
+      promiseArray.push(fillField);
+    }
+    await Promise.all(promiseArray);
+  }
+
+  async loadedCorrectly() {
+    await this.getAppTable();
+    return true;
+  }
+
+  async openCreateApp() {
+    let openCreateAppBtn = await this.findById('openCreateApp');
+    await openCreateAppBtn.click();
+  }
+
+  async getAppTable() {
+    return await this.findById('appsTable');
+  }
+
+  async getAppTableRow(appName) {
+    return await this.findByCss(this._appTableRowSelector(appName));
+  }
+
+  async createApp(appDetails) {
+    await this.openCreateApp();
+    await this._fillAppAttributes(appDetails.getAttributes());
+    await this.submitApp();
+    await this.getAppTableRow(appDetails.name);
+  }
+
+  async openEditApp(appName) {
+    let openEditAppBtn = await this.findByCss(this._appTableRowSelector(appName) + ' button[name="openEditApp"]');
+    await openEditAppBtn.click();
+  }
+
+  async editApp(appDetails) {
+    await this.openEditApp(appDetails.name);
+    await this._fillAppAttributes(appDetails.getEditableAttributes());
+    await this.submitApp();
+  }
+
+  async submitApp() {
+    let submitAppBtn = await this.findById('submitApp');
+    await submitAppBtn.click();
+  }
+
+  //TODO think of a way to generalise this for each app parameter
+  async getAppSyslogUrl(appName) {
+    await this.openEditApp(appName);
+
+    let syslogUrlInput = await this.findById('appSyslogUrl');
+    return await syslogUrlInput.getAttribute('value');
+  }
+
+  async getError() {
+    let flashMessageAlert = await this.findById('flash-messages');
+    return await flashMessageAlert.getText();
+  }
+
+  async openAppOptions(appName) {
+    let moreOptionsBtn = await this.findByCss(this._appTableRowSelector(appName) + ' button[name="openMoreOptions"]');
+    await moreOptionsBtn.click();
+  }
+
+  async deleteApp(appName) {
+    await this.openAppOptions(appName);
+
+    let deleteBtn = await this.findByCss(this._appTableRowSelector(appName) + ' [name="deleteApp"]');
+    await deleteBtn.click();
+
+    let deleteConfirmation = await this.driver.wait(until.alertIsPresent(), 10000, 'Waiting for alert');
+    await deleteConfirmation.accept();
+  }
+};

--- a/test_integration/lib/homepage.js
+++ b/test_integration/lib/homepage.js
@@ -1,26 +1,11 @@
 const {until} = require('selenium-webdriver');
 
-const Page = require('./page.js');
+const FnPage = require('./fn_page.js');
 
-module.exports = class HomePage extends Page {
+module.exports = class HomePage extends FnPage {
 
   _appTableRowSelector(appName) {
     return `#appsTable tr[name="${appName}"]`;
-  }
-
-  async _fillAppAttributes(appAttributes) {
-    let promiseArray = [];
-    for (let i = 0; i < appAttributes.length; i++) {
-      let fillField = this.findById(appAttributes[i].elementId)
-        .then(async function(field) {
-          await field.clear();
-          field.sendKeys(appAttributes[i].value);
-        }
-      );
-
-      promiseArray.push(fillField);
-    }
-    await Promise.all(promiseArray);
   }
 
   async loadedCorrectly() {
@@ -43,7 +28,7 @@ module.exports = class HomePage extends Page {
 
   async createApp(appDetails) {
     await this.openCreateApp();
-    await this._fillAppAttributes(appDetails.getAttributes());
+    await this._fillFormDetails(appDetails.getAttributes());
     await this.submitApp();
     await this.getAppTableRow(appDetails.name);
   }
@@ -55,7 +40,7 @@ module.exports = class HomePage extends Page {
 
   async editApp(appDetails) {
     await this.openEditApp(appDetails.name);
-    await this._fillAppAttributes(appDetails.getEditableAttributes());
+    await this._fillFormDetails(appDetails.getEditableAttributes());
     await this.submitApp();
   }
 
@@ -72,11 +57,6 @@ module.exports = class HomePage extends Page {
     return await syslogUrlInput.getAttribute('value');
   }
 
-  async getError() {
-    let flashMessageAlert = await this.findById('flash-messages');
-    return await flashMessageAlert.getText();
-  }
-
   async openAppOptions(appName) {
     let moreOptionsBtn = await this.findByCss(this._appTableRowSelector(appName) + ' button[name="openMoreOptions"]');
     await moreOptionsBtn.click();
@@ -90,5 +70,10 @@ module.exports = class HomePage extends Page {
 
     let deleteConfirmation = await this.driver.wait(until.alertIsPresent(), 10000, 'Waiting for alert');
     await deleteConfirmation.accept();
+  }
+
+  async visitApp(appName) {
+    let appLink = await this.findByCss(this._appTableRowSelector(appName) + ' [name="appLink"]');
+    await appLink.click();
   }
 };

--- a/test_integration/lib/homepage.js
+++ b/test_integration/lib/homepage.js
@@ -3,12 +3,28 @@ const {until} = require('selenium-webdriver');
 const FnPage = require('./fn_page.js');
 const HomePageSelector = require('./homepage_selector.js');
 
+/*
+ * This class provides an interface to the Homepage page on the Fn UI
+ *
+ * For example, it can be used to create a new app, edit an existing app, etc
+ */
 module.exports = class HomePage extends FnPage {
 
+  // Get the css selector for the provided app's row in the apps table
   _appTableRowSelector(appName) {
     return `#appsTable tr[name="${appName}"]`;
   }
 
+  /*
+   * Get the value of the provided HTML element's field
+   *
+   * @param appName {String} - the name of the Fn App that the field
+   *        belongs to
+   * @param elementDetails {ElementDetails} - an instance of ElementDetails
+   *        containing information on how to locate this HTML element
+   *
+   * @return - the value of the HTML element
+   */
   async _getAppAttribute(appName, elementDetails) {
     await this.openEditApp(appName);
 
@@ -16,24 +32,33 @@ module.exports = class HomePage extends FnPage {
     return await inputField.getAttribute('value');
   }
 
+  // Checks if the homepage loaded correctly
   async loadedCorrectly() {
     await this.getAppTable();
     return true;
   }
 
+  // Opens the CreateApp Modal
   async openCreateApp() {
     let openCreateAppBtn = await this.findByElementDetails(HomePageSelector.openCreateAppBtn());
     await openCreateAppBtn.click();
   }
 
+  // Gets the table containing information about Apps on the Fn server
   async getAppTable() {
     return await this.findByElementDetails(HomePageSelector.appTable());
   }
 
+  // Gets the row containing details about the provided app from the apps table
   async getAppTableRow(appName) {
     return await this.findByElementDetails(HomePageSelector.appTableRow(appName));
   }
 
+  /*
+   * Creates a new Fn App using the homepage
+   *
+   * @param appDetails {AppDetails} - details of the App you want to create
+   */
   async createApp(appDetails) {
     await this.openCreateApp();
     await this._fillFormDetails(appDetails.getAttributes());
@@ -41,27 +66,37 @@ module.exports = class HomePage extends FnPage {
     await this.getAppTableRow(appDetails.name);
   }
 
+  // Opens the EditApp Modal for the specified app
   async openEditApp(appName) {
     let openEditAppBtn = await this.findByElementDetails(HomePageSelector.openEditAppBtn(appName));
     await openEditAppBtn.click();
   }
 
+
+  /*
+   * Edits an existing App using the appDetails provided
+   *
+   * @param appDetails {appDetails} - the new App details you want to use
+   */
   async editApp(appDetails) {
     await this.openEditApp(appDetails.name);
     await this._fillFormDetails(appDetails.getEditableAttributes());
     await this.submitApp();
   }
 
+  // Submits the new/edit App form
   async submitApp() {
     let submitAppBtn = await this.findByElementDetails(HomePageSelector.submitAppBtn());
     await submitAppBtn.click();
   }
 
+  // Opens the more options dropdown for the specified app
   async openAppOptions(appName) {
     let moreOptionsBtn = await this.findByElementDetails(HomePageSelector.openMoreOptionsBtn(appName));
     await moreOptionsBtn.click();
   }
 
+  // Deletes the specified app
   async deleteApp(appName) {
     await this.openAppOptions(appName);
 
@@ -72,11 +107,13 @@ module.exports = class HomePage extends FnPage {
     await deleteConfirmation.accept();
   }
 
+  // Loads the app details page for the specified app
   async visitApp(appName) {
     let appLink = await this.findByElementDetails(HomePageSelector.appLink(appName));
     await appLink.click();
   }
 
+  // Gets the specified apps Syslog URL from the interface
   async getAppSyslogUrl(appName) {
     return await this._getAppAttribute(
       appName, HomePageSelector.appSyslogUrlInput()

--- a/test_integration/lib/homepage.js
+++ b/test_integration/lib/homepage.js
@@ -1,6 +1,7 @@
 const {until} = require('selenium-webdriver');
 
 const FnPage = require('./fn_page.js');
+const HomePageSelector = require('./homepage_selector.js');
 
 module.exports = class HomePage extends FnPage {
 
@@ -14,16 +15,16 @@ module.exports = class HomePage extends FnPage {
   }
 
   async openCreateApp() {
-    let openCreateAppBtn = await this.findById('openCreateApp');
+    let openCreateAppBtn = await this.findByElementDetails(HomePageSelector.openCreateAppBtn());
     await openCreateAppBtn.click();
   }
 
   async getAppTable() {
-    return await this.findById('appsTable');
+    return await this.findByElementDetails(HomePageSelector.appTable());
   }
 
   async getAppTableRow(appName) {
-    return await this.findByCss(this._appTableRowSelector(appName));
+    return await this.findByElementDetails(HomePageSelector.appTableRow(appName));
   }
 
   async createApp(appDetails) {
@@ -34,7 +35,7 @@ module.exports = class HomePage extends FnPage {
   }
 
   async openEditApp(appName) {
-    let openEditAppBtn = await this.findByCss(this._appTableRowSelector(appName) + ' button[name="openEditApp"]');
+    let openEditAppBtn = await this.findByElementDetails(HomePageSelector.openEditAppBtn(appName));
     await openEditAppBtn.click();
   }
 
@@ -45,7 +46,7 @@ module.exports = class HomePage extends FnPage {
   }
 
   async submitApp() {
-    let submitAppBtn = await this.findById('submitApp');
+    let submitAppBtn = await this.findByElementDetails(HomePageSelector.submitAppBtn());
     await submitAppBtn.click();
   }
 
@@ -53,19 +54,19 @@ module.exports = class HomePage extends FnPage {
   async getAppSyslogUrl(appName) {
     await this.openEditApp(appName);
 
-    let syslogUrlInput = await this.findById('appSyslogUrl');
+    let syslogUrlInput = await this.findByElementDetails(HomePageSelector.appSyslogUrlInput(appName));
     return await syslogUrlInput.getAttribute('value');
   }
 
   async openAppOptions(appName) {
-    let moreOptionsBtn = await this.findByCss(this._appTableRowSelector(appName) + ' button[name="openMoreOptions"]');
+    let moreOptionsBtn = await this.findByElementDetails(HomePageSelector.openMoreOptionsBtn(appName));
     await moreOptionsBtn.click();
   }
 
   async deleteApp(appName) {
     await this.openAppOptions(appName);
 
-    let deleteBtn = await this.findByCss(this._appTableRowSelector(appName) + ' [name="deleteApp"]');
+    let deleteBtn = await this.findByElementDetails(HomePageSelector.deleteAppBtn(appName));
     await deleteBtn.click();
 
     let deleteConfirmation = await this.driver.wait(until.alertIsPresent(), 10000, 'Waiting for alert');
@@ -73,7 +74,7 @@ module.exports = class HomePage extends FnPage {
   }
 
   async visitApp(appName) {
-    let appLink = await this.findByCss(this._appTableRowSelector(appName) + ' [name="appLink"]');
+    let appLink = await this.findByElementDetails(HomePageSelector.appLink(appName));
     await appLink.click();
   }
 };

--- a/test_integration/lib/homepage.js
+++ b/test_integration/lib/homepage.js
@@ -9,6 +9,13 @@ module.exports = class HomePage extends FnPage {
     return `#appsTable tr[name="${appName}"]`;
   }
 
+  async _getAppAttribute(appName, elementDetails) {
+    await this.openEditApp(appName);
+
+    let inputField = await this.findByElementDetails(elementDetails);
+    return await inputField.getAttribute('value');
+  }
+
   async loadedCorrectly() {
     await this.getAppTable();
     return true;
@@ -50,14 +57,6 @@ module.exports = class HomePage extends FnPage {
     await submitAppBtn.click();
   }
 
-  //TODO think of a way to generalise this for each app parameter
-  async getAppSyslogUrl(appName) {
-    await this.openEditApp(appName);
-
-    let syslogUrlInput = await this.findByElementDetails(HomePageSelector.appSyslogUrlInput(appName));
-    return await syslogUrlInput.getAttribute('value');
-  }
-
   async openAppOptions(appName) {
     let moreOptionsBtn = await this.findByElementDetails(HomePageSelector.openMoreOptionsBtn(appName));
     await moreOptionsBtn.click();
@@ -76,5 +75,11 @@ module.exports = class HomePage extends FnPage {
   async visitApp(appName) {
     let appLink = await this.findByElementDetails(HomePageSelector.appLink(appName));
     await appLink.click();
+  }
+
+  async getAppSyslogUrl(appName) {
+    return await this._getAppAttribute(
+      appName, HomePageSelector.appSyslogUrlInput()
+    );
   }
 };

--- a/test_integration/lib/homepage_selector.js
+++ b/test_integration/lib/homepage_selector.js
@@ -1,0 +1,55 @@
+const ElementDetails = require('./element_details.js');
+
+function _appTableRowSelector(appName) {
+  return `#appsTable tr[name="${appName}"]`;
+}
+
+function _appTableRowElement(appName, elementSelector) {
+  return new ElementDetails(
+   _appTableRowSelector(appName) + ' ' + elementSelector,
+    ElementDetails.TYPE.CSS
+  );
+}
+
+exports.appTableRow = function(appName) {
+  return new ElementDetails(
+    _appTableRowSelector(appName),
+    ElementDetails.TYPE.CSS
+  );
+};
+
+exports.openCreateAppBtn = function() {
+  return new ElementDetails('openCreateApp', ElementDetails.TYPE.ID);
+};
+
+exports.appTable = function() {
+  return new ElementDetails('appsTable', ElementDetails.TYPE.ID);
+};
+
+exports.submitAppBtn = function() {
+  return new ElementDetails('submitApp', ElementDetails.TYPE.ID);
+};
+
+exports.appNameInput = function() {
+  return new ElementDetails('appName', ElementDetails.TYPE.ID);
+};
+
+exports.appSyslogUrlInput = function() {
+  return new ElementDetails('appSyslogUrl', ElementDetails.TYPE.ID);
+};
+
+exports.openEditAppBtn = function(appName) {
+  return _appTableRowElement(appName, '[name="openEditApp"]');
+};
+
+exports.openMoreOptionsBtn = function(appName) {
+  return _appTableRowElement(appName, '[name="openMoreOptions"]');
+};
+
+exports.deleteAppBtn = function(appName) {
+  return _appTableRowElement(appName, '[name="deleteApp"]');
+};
+
+exports.appLink = function(appName) {
+  return _appTableRowElement(appName, '[name="appLink"]');
+};

--- a/test_integration/lib/homepage_selector.js
+++ b/test_integration/lib/homepage_selector.js
@@ -1,9 +1,18 @@
 const ElementDetails = require('./element_details.js');
 
+/*
+ * This module contains information about how to find elements on the Fn UI's
+ * Homepage
+ */
+
+// Return the CSS selector for the table row which contains information about
+// the specified App
 function _appTableRowSelector(appName) {
   return `#appsTable tr[name="${appName}"]`;
 }
 
+// Helper function for HTML elements which are located in the Apps table.
+// It appends the element's selector to the end of the App Table row selector
 function _appTableRowElement(appName, elementSelector) {
   return new ElementDetails(
    _appTableRowSelector(appName) + ' ' + elementSelector,
@@ -11,6 +20,7 @@ function _appTableRowElement(appName, elementSelector) {
   );
 }
 
+// Return information on how to find the App's row in the Apps table
 exports.appTableRow = function(appName) {
   return new ElementDetails(
     _appTableRowSelector(appName),
@@ -18,38 +28,47 @@ exports.appTableRow = function(appName) {
   );
 };
 
+// Return information on how to find the CreateApp button
 exports.openCreateAppBtn = function() {
   return new ElementDetails('openCreateApp', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the Apps table
 exports.appTable = function() {
   return new ElementDetails('appsTable', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the create/edit App submit button
 exports.submitAppBtn = function() {
   return new ElementDetails('submitApp', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the App Name input field
 exports.appNameInput = function() {
   return new ElementDetails('appName', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the Syslog URL input field
 exports.appSyslogUrlInput = function() {
   return new ElementDetails('appSyslogUrl', ElementDetails.TYPE.ID);
 };
 
+// Return information on how to find the edit App button
 exports.openEditAppBtn = function(appName) {
   return _appTableRowElement(appName, '[name="openEditApp"]');
 };
 
+// Return information on how to find the App more options button
 exports.openMoreOptionsBtn = function(appName) {
   return _appTableRowElement(appName, '[name="openMoreOptions"]');
 };
 
+// Return information on how to find the delete App button
 exports.deleteAppBtn = function(appName) {
   return _appTableRowElement(appName, '[name="deleteApp"]');
 };
 
+// Return information on how to find the link to the App's details page
 exports.appLink = function(appName) {
   return _appTableRowElement(appName, '[name="appLink"]');
 };

--- a/test_integration/lib/page.js
+++ b/test_integration/lib/page.js
@@ -1,8 +1,21 @@
 const {Builder, By, until} = require('selenium-webdriver');
 
+const chrome = require('selenium-webdriver/chrome');
+
+const Config = require('./config.js');
+
 module.exports = class Page {
   constructor() {
+    let config = new Config();
+
+    let chromeOptions = new chrome.Options();
+
+    if(config.get('headless')) {
+      chromeOptions.addArguments('headless');
+    }
+
     this.driver = new Builder()
+      .setChromeOptions(chromeOptions)
       .forBrowser('chrome')
       .build();
   }

--- a/test_integration/lib/page.js
+++ b/test_integration/lib/page.js
@@ -11,6 +11,10 @@ module.exports = class Page {
     return await this.driver.get(url);
   }
 
+  async getCurrentUrl() {
+    return await this.driver.getCurrentUrl();
+  }
+
   async quit() {
     return await this.driver.quit();
   }

--- a/test_integration/lib/page.js
+++ b/test_integration/lib/page.js
@@ -1,0 +1,36 @@
+const {Builder, By, until} = require('selenium-webdriver');
+
+module.exports = class Page {
+  constructor() {
+    this.driver = new Builder()
+      .forBrowser('chrome')
+      .build();
+  }
+
+  async visit(url) {
+    return await this.driver.get(url);
+  }
+
+  async quit() {
+    return await this.driver.quit();
+  }
+
+  async findByLocator(locator) {
+    await this.driver.wait(until.elementLocated(locator), 10000, 'Looking for element: ' + locator);
+    const element = await this.driver.findElement(locator);
+    await this.driver.wait(until.elementIsVisible(element), 10000, 'Waiting for element to become visible: ' + locator);
+    return element;
+  }
+
+  async findById(id) {
+    return await this.findByLocator(By.id(id));
+  }
+
+  async findByCss(selector) {
+    return await this.findByLocator(By.css(selector));
+  }
+
+  async write(element, text) {
+    return await element.sendKeys(text);
+  }
+};

--- a/test_integration/lib/page.js
+++ b/test_integration/lib/page.js
@@ -4,6 +4,9 @@ const chrome = require('selenium-webdriver/chrome');
 
 const Config = require('./config.js');
 
+/*
+ * This class provides functionality for interacting with a page using Selenium
+ */
 module.exports = class Page {
   constructor() {
     let config = new Config();
@@ -20,18 +23,29 @@ module.exports = class Page {
       .build();
   }
 
+  // Visit the specified URL using Selenium
   async visit(url) {
     return await this.driver.get(url);
   }
 
+  // Get the current URL the Selenium driver is on
   async getCurrentUrl() {
     return await this.driver.getCurrentUrl();
   }
 
+  // Quit the Selenium browser
   async quit() {
     return await this.driver.quit();
   }
 
+  /*
+   * Find and return an element on the page once it's visible using its locator
+   *
+   * @param locator {selenium-webdriver.By} - information on how to find the
+   *        element e.g. a By.id(id)
+   *
+   * @return {selenium-webdriver.WebElementPromise}
+   */
   async findByLocator(locator) {
     await this.driver.wait(until.elementLocated(locator), 10000, 'Looking for element: ' + locator);
     const element = await this.driver.findElement(locator);
@@ -39,14 +53,17 @@ module.exports = class Page {
     return element;
   }
 
+  // Find an element on the page by its HTML ID
   async findById(id) {
     return await this.findByLocator(By.id(id));
   }
 
+  // Find an element on the page by its CSS selector
   async findByCss(selector) {
     return await this.findByLocator(By.css(selector));
   }
 
+  // Write the specified text into the specified element
   async write(element, text) {
     return await element.sendKeys(text);
   }

--- a/test_integration/test_app_page.js
+++ b/test_integration/test_app_page.js
@@ -7,10 +7,16 @@ const Config = require('./lib/config.js');
 const FnDetails = require('./lib/fn_details.js');
 const HomePage = require('./lib/homepage.js');
 
+/*
+ * This test uses the Mocha testing framework with Selenium to test
+ * the functionality of the App Details page (/app/$appId)
+ */
 (async function test_app_page() {
   let config = new Config();
   let fn_url = config.get('fn_url');
 
+  // Use a random App name so it's less likely to conflict
+  // with an app that already exists on the Fn server
   let appName = randomstring.generate({
     length: 30,
     charset: 'alphabetic'
@@ -25,6 +31,7 @@ const HomePage = require('./lib/homepage.js');
     describe('Test Fn UI app page', async function() {
       this.timeout(50000);
 
+      // Before running the tests, create an app that we can test against
       let appUrl;
       before(async () => {
         let homepage = new HomePage();
@@ -36,6 +43,7 @@ const HomePage = require('./lib/homepage.js');
         await homepage.quit();
       });
 
+      // Clean up after the tests have completed
       after(async () => {
         let homepage = new HomePage();
         await homepage.visit(fn_url);

--- a/test_integration/test_app_page.js
+++ b/test_integration/test_app_page.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const randomstring = require('randomstring');
+
+const AppDetails = require('./lib/app_details.js');
+const AppPage = require('./lib/app_page.js');
+const FnDetails = require('./lib/fn_details.js');
+const HomePage = require('./lib/homepage.js');
+
+(async function test_app_page() {
+  let appName = randomstring.generate({
+    length: 30,
+    charset: 'alphabetic'
+  });
+  let appDetails = new AppDetails(appName);
+
+  let fnName = 'myFn';
+  let fnImage = 'fndemouser/myFn';
+
+  try {
+
+    describe('Test Fn UI app page', async function() {
+      this.timeout(50000);
+
+      let appUrl;
+      before(async () => {
+        let homepage = new HomePage();
+        await homepage.visit('http://localhost:4000/');
+        await homepage.createApp(appDetails);
+        await homepage.visitApp(appName);
+
+        appUrl = await homepage.getCurrentUrl();
+        await homepage.quit();
+      });
+
+      after(async () => {
+        let homepage = new HomePage();
+        await homepage.visit('http://localhost:4000/');
+        await homepage.deleteApp(appName);
+        await homepage.quit();
+      });
+
+      let appPage;
+      beforeEach(async () => {
+        appPage = new AppPage();
+        await appPage.visit(appUrl);
+      });
+
+      afterEach(async () => {
+        await appPage.quit();
+      });
+
+      it('can load interface', async () => {
+        assert.ok(await appPage.loadedCorrectly());
+      });
+
+      it('can create a function', async () => {
+        let fnDetails = new FnDetails(fnName, fnImage);
+        await appPage.createFn(fnDetails);
+      });
+
+      it('can edit a function', async () => {
+        let newFnImage = fnImage + '2';
+        let fnDetails = new FnDetails(fnName, newFnImage);
+        await appPage.editFn(fnDetails);
+        assert.equal(await appPage.getFnImage(fnDetails.name), newFnImage);
+      });
+
+      it('can delete a function', async () => {
+        await appPage.deleteFn(fnName);
+      });
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(new Error(err.message));
+  }
+})();

--- a/test_integration/test_app_page.js
+++ b/test_integration/test_app_page.js
@@ -3,10 +3,14 @@ const randomstring = require('randomstring');
 
 const AppDetails = require('./lib/app_details.js');
 const AppPage = require('./lib/app_page.js');
+const Config = require('./lib/config.js');
 const FnDetails = require('./lib/fn_details.js');
 const HomePage = require('./lib/homepage.js');
 
 (async function test_app_page() {
+  let config = new Config();
+  let fn_url = config.get('fn_url');
+
   let appName = randomstring.generate({
     length: 30,
     charset: 'alphabetic'
@@ -24,7 +28,7 @@ const HomePage = require('./lib/homepage.js');
       let appUrl;
       before(async () => {
         let homepage = new HomePage();
-        await homepage.visit('http://localhost:4000/');
+        await homepage.visit(fn_url);
         await homepage.createApp(appDetails);
         await homepage.visitApp(appName);
 
@@ -34,7 +38,7 @@ const HomePage = require('./lib/homepage.js');
 
       after(async () => {
         let homepage = new HomePage();
-        await homepage.visit('http://localhost:4000/');
+        await homepage.visit(fn_url);
         await homepage.deleteApp(appName);
         await homepage.quit();
       });

--- a/test_integration/test_app_page.js
+++ b/test_integration/test_app_page.js
@@ -65,6 +65,14 @@ const HomePage = require('./lib/homepage.js');
         assert.equal(await appPage.getFnImage(fnDetails.name), newFnImage);
       });
 
+      it('should disallow large memory allocation', async () => {
+        let fnDetails = new FnDetails(fnName, null, Number.MAX_SAFE_INTEGER);
+        await appPage.editFn(fnDetails);
+
+        let errorText = await appPage.getError();
+        assert.ok(errorText.includes('out of range'));
+      });
+
       it('can delete a function', async () => {
         await appPage.deleteFn(fnName);
       });

--- a/test_integration/test_homepage.js
+++ b/test_integration/test_homepage.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const randomstring = require('randomstring');
+
+const AppDetails = require('./lib/app_details.js');
+const HomePage = require('./lib/homepage.js');
+
+(async function test_homepage() {
+  try {
+    describe('Test Fn UI homepage', async function() {
+      this.timeout(50000);
+      let appName = randomstring.generate({
+        length: 30,
+        charset: 'alphabetic'
+      });
+
+      let page;
+      beforeEach(async () => {
+        page = new HomePage();
+        await page.visit('http://localhost:4000/');
+      });
+
+      afterEach (async () => {
+        await page.quit();
+      });
+
+      it('can load interface', async () => {
+        assert.ok(await page.loadedCorrectly());
+      });
+
+      it('can create an app', async () => {
+        let appDetails = new AppDetails(appName);
+        await page.createApp(appDetails);
+      });
+
+      it('can edit an app', async () => {
+        let syslogUrl = 'tcp://syslogserver.invalid';
+        let appDetails = new AppDetails(appName, syslogUrl);
+        await page.editApp(appDetails);
+        assert.equal(await page.getAppSyslogUrl(appDetails.name), syslogUrl);
+      });
+
+      it('should disallow invalid syslog urls', async () => {
+        let appDetails = new AppDetails(appName, 'invalid-syslog-url');
+        await page.editApp(appDetails);
+
+        let errorText = await page.getError();
+        assert.ok(errorText.includes('invalid syslog url'));
+      });
+
+      it('can delete an app', async () => {
+        await page.deleteApp(appName);
+      });
+    });
+  } catch (ex) {
+    // eslint-disable-next-line no-console
+    console.error(new Error(ex.message));
+  }
+})();

--- a/test_integration/test_homepage.js
+++ b/test_integration/test_homepage.js
@@ -5,10 +5,17 @@ const AppDetails = require('./lib/app_details.js');
 const Config = require('./lib/config.js');
 const HomePage = require('./lib/homepage.js');
 
+/*
+ * This test uses the Mocha testing framewith with Selenium to test
+ * the functionality of the Fn UI's homepage
+ */
 (async function test_homepage() {
   try {
     describe('Test Fn UI homepage', async function() {
       this.timeout(50000);
+
+      // Use a random App name so it's less likely to conflict
+      // with an app that already exists on the Fn server
       let appName = randomstring.generate({
         length: 30,
         charset: 'alphabetic'
@@ -36,6 +43,7 @@ const HomePage = require('./lib/homepage.js');
       });
 
       it('can edit an app', async () => {
+        // Use the .invalid TLD so it doesn't link to an actual syslog server
         let syslogUrl = 'tcp://syslogserver.invalid';
         let appDetails = new AppDetails(appName, syslogUrl);
         await page.editApp(appDetails);

--- a/test_integration/test_homepage.js
+++ b/test_integration/test_homepage.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const randomstring = require('randomstring');
 
 const AppDetails = require('./lib/app_details.js');
+const Config = require('./lib/config.js');
 const HomePage = require('./lib/homepage.js');
 
 (async function test_homepage() {
@@ -16,7 +17,9 @@ const HomePage = require('./lib/homepage.js');
       let page;
       beforeEach(async () => {
         page = new HomePage();
-        await page.visit('http://localhost:4000/');
+        let config = new Config();
+        let fn_url = config.get('fn_url');
+        await page.visit(fn_url);
       });
 
       afterEach (async () => {


### PR DESCRIPTION
I've added Selenium integration tests for the Fn UI meaning that we can automatically test basic Fn UI functionality. This should help with cases like #71 where we need to test the entire system.

I'm not sure if I've used async/await correctly - I've basically made the entire thing synchronous (apart from where I fill in form input fields). However, as I need Selenium to do things in order and the Selenium webdriver functions return promises, I'm being forced to do this. I either need to do this or use promise chaining and I feel promise chaining is a lot less maintainable. If you have any other suggestions, please let me know.

## Testing
Apart from adding a few IDs/Name tags to HTML elements, the changes should be self contained and won't affect the Fn UI so testing should be straight forward. 

To test, follow the instructions under `Automated Testing` on the readme [test_integration/etc/config.yaml](https://github.com/vzDevelopment/ui/blob/844d0ee91e6552a1abacd3356804d34e545a3a4a/README.md)

## Results
Here's a little gif of it working with headless set to false in the config

![Selenium](https://user-images.githubusercontent.com/49067415/58010370-23045a80-7ae8-11e9-95b2-e92bc0fb282d.gif)